### PR TITLE
Function overloads to accept an array of viewcontrollers as children

### DIFF
--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -99,6 +99,13 @@ open class FamilyViewController: UIViewController {
   ///
   /// - Parameter childControllers: The view controllers to be added as children.
   public func addChildViewControllers(_ childControllers: UIViewController ...) {
+    addChildViewControllers(childControllers)
+  }
+
+  /// Adds a collection of view controllers as children of the current view controller.
+  ///
+  /// - Parameter childControllers: The view controllers to be added as children.
+  public func addChildViewControllers(_ childControllers: [UIViewController]) {
     for childController in childControllers {
       addChildViewController(childController)
     }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -55,6 +55,10 @@ public class FamilyViewController: NSViewController, FamilyFriendly {
   }
 
   public func addChildViewControllers(_ childControllers: NSViewController ...) {
+    addChildViewControllers(childControllers)
+  }
+
+  public func addChildViewControllers(_ childControllers: [NSViewController]) {
     for childController in childControllers {
       addChildViewController(childController)
     }


### PR DESCRIPTION
I've added overloads that accept an array of ViewControllers, so that it's possible to separate the creation of controllers from their addition to the hierarchy.

This pull request contains all the changes needed for (i/tv)OS and macOS implementations