### PR TITLE
Fix bug where horizontal components didn't render properly on macOS.

### DIFF
--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -221,6 +221,7 @@ public class FamilyScrollView: NSScrollView {
       instance.documentView?.frame.size.height = contentSize.height
     } else {
       instance.documentView?.frame.size = contentSize
+      instance.frame.size.height = contentSize.height
       instance.frame.size.width = self.frame.width
       instance.frame.origin.y = currentYOffset
     }


### PR DESCRIPTION
Set the frame size height to the content size of the document view. This fixes a bug where horizontal component did not render properly because the wrapper view never received a proper height.