### PR TITLE
Add .isHidden functionality like a stack view

### DIFF
--- a/FamilyTests/iOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/iOS/FamilyViewControllerTests.swift
@@ -60,7 +60,13 @@ class FamilyViewControllerTests: XCTestCase {
 
     XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1500)
     secondViewController.view.isHidden = true
-    XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1000)
+
+    #if os(iOS)
+      XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1000)
+    #else
+      XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1080)
+    #endif
+
   }
 
   func testAddingCustomViewFromController() {

--- a/FamilyTests/iOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/iOS/FamilyViewControllerTests.swift
@@ -38,6 +38,11 @@ class FamilyViewControllerTests: XCTestCase {
     let firstViewController = UIViewController()
     let secondViewController = UIViewController()
     let thirdViewController = UIViewController()
+
+    firstViewController.view.frame.size.height = 500
+    secondViewController.view.frame.size.height = 500
+    thirdViewController.view.frame.size.height = 500
+
     familyViewController.addChildViewControllers(firstViewController,
                                                  secondViewController,
                                                  thirdViewController)
@@ -52,6 +57,10 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(wrapperView, secondViewController.view.superview)
     wrapperView = (familyViewController.scrollView.contentView.subviews[2] as? FamilyWrapperView)
     XCTAssertEqual(wrapperView, thirdViewController.view.superview)
+
+    XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1500)
+    secondViewController.view.isHidden = true
+    XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1000)
   }
 
   func testAddingCustomViewFromController() {

--- a/FamilyTests/macOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/macOS/FamilyViewControllerTests.swift
@@ -32,6 +32,7 @@ class FamilyViewControllerTests: XCTestCase {
     super.setUp()
     familyViewController = FamilyViewController()
     familyViewController.prepareViewController()
+    NSAnimationContext.current.duration = 0.0
   }
 
   func testAddingChildViewController() {
@@ -45,6 +46,11 @@ class FamilyViewControllerTests: XCTestCase {
     let firstViewController = MockViewController()
     let secondViewController = MockViewController()
     let thirdViewController = MockViewController()
+
+    firstViewController.view.frame.size.height = 500
+    secondViewController.view.frame.size.height = 500
+    thirdViewController.view.frame.size.height = 500
+
     familyViewController.addChildViewControllers(firstViewController,
                                                  secondViewController,
                                                  thirdViewController)
@@ -61,6 +67,11 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(wrapperView?.documentView, secondViewController.view)
     wrapperView = (subviews[2] as? FamilyWrapperView)
     XCTAssertEqual(wrapperView?.documentView, thirdViewController.view)
+
+    familyViewController.scrollView.layoutViews(withDuration: 0)
+    XCTAssertEqual(familyViewController.scrollView.documentView?.frame.size.height, 1500)
+    secondViewController.view.isHidden = true
+    XCTAssertEqual(familyViewController.scrollView.documentView?.frame.size.height, 1000)
   }
 
   func testAddingCustomViewFromController() {

--- a/Sources/iOS+tvOS/Classes/FamilyContentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyContentView.swift
@@ -6,6 +6,8 @@ import UIKit
 /// only needs to take `UIScrollView` based views into account when performing
 /// its layout algorithm.
 final public class FamilyContentView: UIView {
+  weak var familyScrollView: FamilyScrollView?
+
   /// Convenience methods to return all subviews as scroll view.
   var scrollViews: [UIScrollView] {
     return subviews.flatMap { $0 as? UIScrollView }
@@ -27,6 +29,7 @@ final public class FamilyContentView: UIView {
     default:
       let wrapper = FamilyWrapperView(frame: view.frame,
                                       view: view)
+      wrapper.parentContentView = self
       subview = wrapper
     }
 
@@ -40,10 +43,8 @@ final public class FamilyContentView: UIView {
   ///
   /// - Parameter subview: The view that got added as a subview.
   override open func didAddSubview(_ subview: UIView) {
-    resolveFamilyScrollView {
-      if let scrollView = subview as? UIScrollView {
-        $0.didAddScrollViewToContainer(scrollView)
-      }
+    if let scrollView = subview as? UIScrollView {
+      familyScrollView?.didAddScrollViewToContainer(scrollView)
     }
   }
 
@@ -54,23 +55,13 @@ final public class FamilyContentView: UIView {
   /// - Parameter subview: The subview that will be removed.
   override open func willRemoveSubview(_ subview: UIView) {
     super.willRemoveSubview(subview)
-    resolveFamilyScrollView { $0.willRemoveSubview(subview) }
+    familyScrollView?.willRemoveSubview(subview)
   }
 
   /// Lays out subviews.
   open override func layoutSubviews() {
     super.layoutSubviews()
-    resolveFamilyScrollView { $0.setNeedsLayout() }
-  }
-
-  /// Resolves the super view as `FamilyScrollView`.
-  ///
-  /// - Parameter closure: A closure that will be called when the `.superview`
-  ///                      has been resolved as a `FamilyScrollView`.
-  private func resolveFamilyScrollView(closure: (FamilyScrollView) -> Void) {
-    if let familyScrollView = superview as? FamilyScrollView {
-      closure(familyScrollView)
-    }
+    familyScrollView?.setNeedsLayout()
   }
 }
 

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -4,11 +4,13 @@ import UIKit
 /// from `UIScrollView`. This is done to ensure that the user gets a fluid and
 /// smooth scrolling experience when scrolling in a `FamilyScrollView`.
 final class FamilyWrapperView: UIScrollView {
+  weak var parentContentView: FamilyContentView?
   /// The wrapped view
   var view: UIView
   /// Observers the frame of the wrapped view.
   /// The frame size of the wrapped view is used for content size.
-  private var observer: NSKeyValueObservation?
+  private var frameObserver: NSKeyValueObservation?
+  private var hiddenObserver: NSKeyValueObservation?
 
   /// Initializes and returns a newly allocated view object with the specified frame rectangle.
   /// The view that gets passed will be used as the wrapped view for the `FamilyWrapperView`.
@@ -20,9 +22,17 @@ final class FamilyWrapperView: UIScrollView {
     self.view = view
     super.init(frame: frame)
 
-    observer = view.observe(\.frame, options: [.initial, .new]) { [weak self] (view, value) in
+    frameObserver = view.observe(\.frame, options: [.initial, .new]) { [weak self] (view, value) in
       if let rect = value.newValue {
         self?.setWrapperFrameSize(rect)
+      }
+    }
+
+    hiddenObserver = view.observe(\.isHidden, options: [.initial, .new, .old]) { [weak self] (_, value) in
+      if value.newValue != value.oldValue, let newValue = value.newValue {
+        self?.isHidden = newValue
+        self?.parentContentView?.familyScrollView?.setNeedsLayout()
+        self?.parentContentView?.familyScrollView?.layoutIfNeeded()
       }
     }
 

--- a/Sources/macOS/Classes/FamilyContentView.swift
+++ b/Sources/macOS/Classes/FamilyContentView.swift
@@ -3,6 +3,8 @@ import Cocoa
 public class FamilyContentView: NSView {
   public override var isFlipped: Bool { return true }
 
+  weak var familyScrollView: FamilyScrollView?
+
   var scrollViews: [NSScrollView] {
     return subviews.flatMap { $0 as? NSScrollView }
   }
@@ -16,6 +18,7 @@ public class FamilyContentView: NSView {
     default:
       let wrapper = FamilyWrapperView(frame: view.frame,
                                       wrappedView: view)
+      wrapper.parentContentView = self
       subview = wrapper
     }
     super.addSubview(subview)
@@ -23,25 +26,17 @@ public class FamilyContentView: NSView {
 
   override public func didAddSubview(_ subview: NSView) {
     super.didAddSubview(subview)
-    resolveFamilyScrollView {
-      if let scrollView = subview as? NSScrollView {
-        $0.didAddScrollViewToContainer(scrollView)
-      }
+    if let scrollView = subview as? NSScrollView {
+      familyScrollView?.didAddScrollViewToContainer(scrollView)
     }
   }
 
   override public func willRemoveSubview(_ subview: NSView) {
-    resolveFamilyScrollView { $0.willRemoveSubview(subview) }
+    familyScrollView?.willRemoveSubview(subview)
   }
 
   override public func scroll(_ point: NSPoint) {
     super.scroll(point)
-    resolveFamilyScrollView { $0.layoutViews() }
-  }
-
-  private func resolveFamilyScrollView(closure: (FamilyScrollView) -> Void) {
-    if let familyScrollView = enclosingScrollView as? FamilyScrollView {
-      closure(familyScrollView)
-    }
+    familyScrollView?.layoutViews()
   }
 }


### PR DESCRIPTION
Adds isHidden behavior that is similar to what you get from a regular stack view. If the underlying view decides to not render anymore, the FamilyScrollView will discard the view from the layout algorithm.