### PR TITLE
Add observers for child views that use custom views

### DIFF
--- a/FamilyTests/iOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/iOS/FamilyViewControllerTests.swift
@@ -66,16 +66,25 @@ class FamilyViewControllerTests: XCTestCase {
     #else
       XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1080)
     #endif
-
   }
 
   func testAddingCustomViewFromController() {
-    let mockedViewController = MockViewController()
-    familyViewController.addChildViewController(mockedViewController, view: { $0.scrollView })
+    let mockedViewController1 = MockViewController()
+    let mockedViewController2 = MockViewController()
+    familyViewController.addChildViewController(mockedViewController1, view: { $0.scrollView })
+    familyViewController.addChildViewController(mockedViewController2, view: { $0.scrollView })
 
-    XCTAssertEqual(mockedViewController.parent, familyViewController)
-    XCTAssertEqual(familyViewController.childViewControllers.count, 1)
-    XCTAssertEqual(familyViewController.scrollView.contentView, mockedViewController.scrollView.superview)
+    XCTAssertEqual(mockedViewController1.parent, familyViewController)
+    XCTAssertEqual(mockedViewController2.parent, familyViewController)
+    XCTAssertEqual(familyViewController.childViewControllers.count, 2)
+    XCTAssertEqual(familyViewController.scrollView.contentView, mockedViewController1.scrollView.superview)
+    XCTAssertEqual(familyViewController.scrollView.contentView, mockedViewController2.scrollView.superview)
+
+    XCTAssertEqual(familyViewController.registry.count, 2)
+    mockedViewController1.removeFromParentViewController()
+    XCTAssertEqual(familyViewController.registry.count, 1)
+    mockedViewController2.removeFromParentViewController()
+    XCTAssertEqual(familyViewController.registry.count, 0)
   }
 
   func testAddingChildViewControllerWithConstraintedHeight() {

--- a/FamilyTests/macOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/macOS/FamilyViewControllerTests.swift
@@ -75,12 +75,22 @@ class FamilyViewControllerTests: XCTestCase {
   }
 
   func testAddingCustomViewFromController() {
-    let mockedViewController = MockScrollViewController()
-    familyViewController.addChildViewController(mockedViewController, view: { $0.scrollView })
-
-    XCTAssertEqual(mockedViewController.parent, familyViewController)
-    XCTAssertEqual(familyViewController.childViewControllers.count, 1)
-    XCTAssertEqual(familyViewController.scrollView.documentView, mockedViewController.scrollView.superview)
+    let mockedViewController1 = MockScrollViewController()
+    let mockedViewController2 = MockScrollViewController()
+    familyViewController.addChildViewController(mockedViewController1, view: { $0.scrollView })
+    familyViewController.addChildViewController(mockedViewController2, view: { $0.scrollView })
+    
+    XCTAssertEqual(mockedViewController1.parent, familyViewController)
+    XCTAssertEqual(mockedViewController2.parent, familyViewController)
+    XCTAssertEqual(familyViewController.childViewControllers.count, 2)
+    XCTAssertEqual(familyViewController.scrollView.documentView, mockedViewController1.scrollView.superview)
+    XCTAssertEqual(familyViewController.scrollView.documentView, mockedViewController2.scrollView.superview)
+    
+    XCTAssertEqual(familyViewController.registry.count, 2)
+    mockedViewController1.removeFromParentViewController()
+    XCTAssertEqual(familyViewController.registry.count, 1)
+    mockedViewController2.removeFromParentViewController()
+    XCTAssertEqual(familyViewController.registry.count, 0)
   }
 
   func testAddingChildViewControllerWithConstraintedHeight() {

--- a/Sources/Shared/FamilyFriendly.swift
+++ b/Sources/Shared/FamilyFriendly.swift
@@ -1,8 +1,13 @@
 import CoreGraphics
+import Foundation
 
 protocol FamilyFriendly: class {
+  var registry: [ViewController: View] { get set }
+
   func addChildViewController(_ childController: ViewController)
   func addChildViewController(_ childController: ViewController, height: CGFloat)
   func addChildViewController<T: ViewController>(_ childController: T, view closure: (T) -> View)
   func addChildViewControllers(_ childControllers: ViewController ...)
+
+  func purgeRemovedViews()
 }


### PR DESCRIPTION
When removing a child view controllers that was added with a custom view, we need to remove the custom view from the view hierarchy. Child view controllers that have custom views are now observed and purged when they are removed from the parent view controller.