### PR TITLE
Set content size width using max()

### DIFF
--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -218,7 +218,8 @@ public class FamilyScrollView: NSScrollView {
       wrapperView.documentView?.frame.size.width = self.frame.width
       wrapperView.documentView?.frame.size.height = contentSize.height
     } else {
-      wrapperView.documentView?.frame.size = contentSize
+      wrapperView.documentView?.frame.size.width = max(contentSize.width, self.frame.width)
+      wrapperView.documentView?.frame.size.height = contentSize.height
       wrapperView.frame.size.height = contentSize.height
       wrapperView.frame.size.width = self.frame.width
       wrapperView.frame.origin.y = currentYOffset


### PR DESCRIPTION
The content size width should never be less than the windows width. This is achieved by using `max()` on the content size width, and the windows frame width. 