### PR TITLE
Modify content offset if only one component is used

### DIFF
--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -309,6 +309,7 @@ public final class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
         }
       case false:
         newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
+        scrollView.contentOffset.y = contentOffset.y
       }
 
       frame.size.height = newHeight


### PR DESCRIPTION
This fixes a scrolling issue with the `FamilyScrollView` on iOS and tvOS. When you only use one controller the underlying scroll views wouldn't scroll correctly.