### PR TITLE
Fix with adding custom spacing using `addChildViewController`

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.0"
+  s.version          = "0.5.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -105,7 +105,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     registry[childController] = childController.view
 
     if let customSpacing = customSpacing {
-      setCustomSpacing(customSpacing, after: view)
+      setCustomSpacing(customSpacing, after: childController.view)
     }
   }
 

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -56,7 +56,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     scrollView.frame = view.bounds
 
     if let spacing = spacing {
-      setCustomSpacing(spacing, after: view)
+      setCustomSpacing(spacing, after: childController.view)
     }
   }
 


### PR DESCRIPTION
This fixes a bug that occurred when using custom spacing with the `addChildViewController` method.
It added the wrong view to the registry.