### PR TITLE
Improve using observers for view controllers on iOS and tvOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.3"
+  s.version          = "0.5.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/FamilyFriendly.swift
+++ b/Sources/Shared/FamilyFriendly.swift
@@ -2,8 +2,6 @@ import CoreGraphics
 import Foundation
 
 protocol FamilyFriendly: class {
-  var registry: [ViewController: View] { get set }
-
   func addChildViewController(_ childController: ViewController)
   func addChildViewController(_ childController: ViewController, customSpacing: CGFloat?, height: CGFloat)
   func addChildViewController<T: ViewController>(_ childController: T, customSpacing: CGFloat?, view closure: (T) -> View)


### PR DESCRIPTION
Instead of keeping a separate array of observers, the observers are now added to the registry.