### PR TITLE
Store and make scroll view constraints available in the public API

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.4"
+  s.version          = "0.5.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -7,11 +7,12 @@ import UIKit
 /// content view of the `FamilyScrollView`.
 open class FamilyViewController: UIViewController, FamilyFriendly {
 //  var observers = [NSKeyValueObservation]()
-  var registry = [ViewController : (view: View, observer: NSKeyValueObservation)]()
+  var registry = [ViewController: (view: View, observer: NSKeyValueObservation)]()
 
   /// A custom implementation of a `UIScrollView` that handles continious scrolling
   /// when using scroll views inside of scroll view.
   public lazy var scrollView: FamilyScrollView = FamilyScrollView()
+  public var constraints = [NSLayoutConstraint]()
 
   deinit {
     childViewControllers.forEach { $0.removeFromParentViewController() }
@@ -43,7 +44,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   }
 
   /// Called to notify the view controller that its view is about to layout its subviews.
-  override open func viewWillLayoutSubviews() {
+  open override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
     scrollView.frame = view.bounds
     scrollView.contentView.frame = scrollView.bounds
@@ -53,24 +54,30 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
     if #available(iOS 11.0, tvOS 11.0, *) {
-      scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-      scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-      scrollView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-      scrollView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+      constraints.append(contentsOf: [
+        scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+        scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        scrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
+        scrollView.rightAnchor.constraint(equalTo: view.rightAnchor)
+      ])
     } else {
       if #available(iOS 9.0, *) {
-        scrollView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor).isActive = true
-        scrollView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor).isActive = true
-        scrollView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        scrollView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        constraints.append(contentsOf: [
+          scrollView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor),
+          scrollView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
+          scrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
+          scrollView.rightAnchor.constraint(equalTo: view.rightAnchor)
+        ])
       }
     }
+
+    NSLayoutConstraint.activate(constraints)
   }
 
   /// Adds the specified view controller as a child of the current view controller.
   ///
   /// - Parameter childController: The view controller to be added as a child.
-  override open func addChildViewController(_ childController: UIViewController) {
+  open override func addChildViewController(_ childController: UIViewController) {
     purgeRemovedViews()
     childController.willMove(toParentViewController: self)
     super.addChildViewController(childController)
@@ -184,7 +191,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   }
 
   private func observe(_ childController: UIViewController) -> NSKeyValueObservation {
-    let observer = childController.observe(\.parent, options: [.new, .old]) { [weak self] (_, value) in
+    let observer = childController.observe(\.parent, options: [.new, .old]) { [weak self] _, _ in
       self?.purgeRemovedViews()
     }
     return observer

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -12,6 +12,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// A custom implementation of a `UIScrollView` that handles continious scrolling
   /// when using scroll views inside of scroll view.
   public lazy var scrollView: FamilyScrollView = FamilyScrollView()
+  /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
 
   deinit {

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -2,6 +2,7 @@ import Cocoa
 
 open class FamilyViewController: NSViewController, FamilyFriendly {
   public lazy var scrollView: FamilyScrollView = .init()
+  /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
   var registry = [ViewController: View]()
   var observer: NSKeyValueObservation?

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -2,9 +2,9 @@ import Cocoa
 
 open class FamilyViewController: NSViewController, FamilyFriendly {
   public lazy var scrollView: FamilyScrollView = .init()
+  public var constraints = [NSLayoutConstraint]()
   var registry = [ViewController: View]()
   var observer: NSKeyValueObservation?
-  var topAnchorConstraint: NSLayoutConstraint?
 
   deinit {
     childViewControllers.forEach { $0.removeFromParentViewController() }
@@ -17,12 +17,12 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     view.autoresizesSubviews = true
     self.view = view
 
-    observer = observe(\.childViewControllers, options: [.new, .old], changeHandler: { (controller, _) in
+    observer = observe(\.childViewControllers, options: [.new, .old], changeHandler: { controller, _ in
       controller.purgeRemovedViews()
     })
   }
 
-  override open func viewDidLoad() {
+  open override func viewDidLoad() {
     super.viewDidLoad()
     view.addSubview(scrollView)
     scrollView.autoresizingMask = [.width]
@@ -32,14 +32,17 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
     if #available(OSX 10.11, *) {
-      scrollView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-      scrollView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-      scrollView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
-      scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+      constraints.append(contentsOf: [
+        scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+        scrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
+        scrollView.rightAnchor.constraint(equalTo: view.rightAnchor),
+        scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+      ])
+      NSLayoutConstraint.activate(constraints)
     }
   }
 
-  override open func addChildViewController(_ childController: ViewController) {
+  open override func addChildViewController(_ childController: ViewController) {
     super.addChildViewController(childController)
     childController.view.frame.size.width = view.bounds.width
     scrollView.familyContentView.addSubview(childController.view)


### PR DESCRIPTION
The constraints for the scroll view are now stored in an array so that you can deactivate or change them if needed.