### PR TITLE
Constrain width of frame to width of FamilyScrollView

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.5"
+  s.version          = "0.5.6"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -306,6 +306,8 @@ public final class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
       let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
       var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
 
+      frame.size.width = max(frame.size.width, self.frame.size.width)
+
       switch multipleComponents {
       case true:
         if scrollView is FamilyWrapperView {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -175,6 +175,9 @@ public class FamilyScrollView: NSScrollView {
       let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)
       let remainingContentHeight = fmax(contentSize.height - contentOffset.y, 0.0)
       var newHeight: CGFloat = fmin(remainingBoundsHeight, remainingContentHeight)
+
+      frame.size.width = max(frame.size.width, self.frame.size.width)
+
       let shouldModifyContentOffset = contentOffset.y - contentInsets.top <= scrollView.contentSize.height + (contentInsets.top * 2) ||
         self.contentOffset.y != frame.minY
 


### PR DESCRIPTION
This constrains the width of subview to never exceed beyond the width of the `FamilyScrollView`.