### PR TITLE
Fix scrollIndicatorInsets on iOS 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.3beta
+osx_image: xcode9.4
 language: objective-c
 
 script:
@@ -6,8 +6,8 @@ script:
   - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-macOS" -sdk macosx -enableCodeCoverage YES test
   - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-iOS" -sdk iphonesimulator -destination name="iPhone 8" clean build
   - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-iOS" -sdk iphonesimulator -destination name="iPhone 8" -enableCodeCoverage YES test
-  - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=11.0' clean build
-  - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=11.0' -enableCodeCoverage YES test
+  - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 4K (at 1080p),OS=11.4' clean build
+  - set -o pipefail && xcodebuild -project Family.xcodeproj -scheme "Family-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 4K (at 1080p),OS=11.4' -enableCodeCoverage YES test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.7"
+  s.version          = "0.5.8"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/FamilyTests/iOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/iOS/FamilyViewControllerTests.swift
@@ -102,8 +102,10 @@ class FamilyViewControllerTests: XCTestCase {
 
     familyViewController.viewWillAppear(false)
 
-    XCTAssertEqual(familyViewController.scrollView.contentInset.bottom,
-                   tabBarController.tabBar.frame.size.height)
+    if #available(iOS 11.0, *) {} else {
+      XCTAssertEqual(familyViewController.scrollView.contentInset.bottom,
+                     tabBarController.tabBar.frame.size.height)
+    }
     XCTAssertEqual(familyViewController.scrollView.contentInset.bottom,
                    familyViewController.scrollView.scrollIndicatorInsets.bottom)
   }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -39,8 +39,10 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     super.viewWillAppear(animated)
 
     if let tabBarController = self.tabBarController, tabBarController.tabBar.isTranslucent {
-      scrollView.contentInset.bottom = tabBarController.tabBar.frame.size.height
-      scrollView.scrollIndicatorInsets.bottom = scrollView.contentInset.bottom
+      if #available(iOS 11.0, *) {} else {
+        scrollView.contentInset.bottom = tabBarController.tabBar.frame.size.height
+        scrollView.scrollIndicatorInsets.bottom = scrollView.contentInset.bottom
+      }
     }
   }
 


### PR DESCRIPTION
If iOS version is 11 or higher, do not apply any scrollIndicatorInsets changes to the scroll view.