### PR TITLE
Improve wrapper view cleanup

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.8"
+  s.version          = "0.5.9"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -98,6 +98,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
 
     childController.didMove(toParentViewController: self)
     registry[childController] = (childController.view, observe(childController))
+    purgeWrapperViews()
   }
 
   /// Adds the specified view controller as a child of the current view controller.
@@ -118,6 +119,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     if let customSpacing = customSpacing {
       setCustomSpacing(customSpacing, after: childController.view)
     }
+
+    purgeWrapperViews()
   }
 
   /// Adds the specified view controller as a child of the current view controller.
@@ -138,6 +141,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     addView(childView, customSpacing: spacing)
     childController.didMove(toParentViewController: self)
     registry[childController] = (childView, observe(childController))
+    purgeWrapperViews()
   }
 
   /// Adds a collection of view controllers as children of the current view controller.
@@ -178,6 +182,15 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
 
   public func setCustomSpacing(_ spacing: CGFloat, after view: View) {
     scrollView.setCustomSpacing(spacing, after: view)
+  }
+
+  /// Remove wrapper views that don't own their underlaying views.
+  func purgeWrapperViews() {
+    for case let wrapperView as FamilyWrapperView in scrollView.contentView.subviews {
+      if wrapperView != wrapperView.view.superview {
+        wrapperView.removeFromSuperview()
+      }
+    }
   }
 
   /// Remove stray views from view hierarcy.


### PR DESCRIPTION
To make sure that the hierarchy is up-to-date when adding new child view controllers, wrapper views will now be validated and removed if they don't own their underlaying view.