### PR TITLE
Improve view cleanup

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.9"
+  s.version          = "0.5.10"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/FamilySpaceManager.swift
+++ b/Sources/Shared/FamilySpaceManager.swift
@@ -45,4 +45,10 @@ class FamilySpaceManager {
     registry.forEach { $0.key.removeFromSuperview() }
     registry.removeAll()
   }
+
+  func removeViewsWithoutSuperview() {
+    for (view, _) in registry where view.superview == nil {
+      removeView(view)
+    }
+  }
 }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -250,6 +250,16 @@ public final class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
     spaceManager.setCustomSpacing(spacing, after: view)
   }
 
+  /// Remove wrapper views that don't own their underlaying views.
+  func purgeWrapperViews() {
+    for case let wrapperView as FamilyWrapperView in contentView.subviews {
+      if wrapperView != wrapperView.view.superview {
+        wrapperView.removeFromSuperview()
+      }
+    }
+
+  }
+
   /// This methods decides if the layout algoritm should be performed with
   /// animation. When a `duration` is based, the algorithm will use this
   /// `duration` and run the algorithm inside an animation block.

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -258,6 +258,7 @@ public final class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
       }
     }
 
+    spaceManager.removeViewsWithoutSuperview()
   }
 
   /// This methods decides if the layout algoritm should be performed with

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -98,7 +98,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
 
     childController.didMove(toParentViewController: self)
     registry[childController] = (childController.view, observe(childController))
-    purgeWrapperViews()
+    scrollView.purgeWrapperViews()
   }
 
   /// Adds the specified view controller as a child of the current view controller.
@@ -120,7 +120,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       setCustomSpacing(customSpacing, after: childController.view)
     }
 
-    purgeWrapperViews()
+    scrollView.purgeWrapperViews()
   }
 
   /// Adds the specified view controller as a child of the current view controller.
@@ -141,7 +141,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     addView(childView, customSpacing: spacing)
     childController.didMove(toParentViewController: self)
     registry[childController] = (childView, observe(childController))
-    purgeWrapperViews()
+    scrollView.purgeWrapperViews()
   }
 
   /// Adds a collection of view controllers as children of the current view controller.
@@ -182,15 +182,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
 
   public func setCustomSpacing(_ spacing: CGFloat, after view: View) {
     scrollView.setCustomSpacing(spacing, after: view)
-  }
-
-  /// Remove wrapper views that don't own their underlaying views.
-  func purgeWrapperViews() {
-    for case let wrapperView as FamilyWrapperView in scrollView.contentView.subviews {
-      if wrapperView != wrapperView.view.superview {
-        wrapperView.removeFromSuperview()
-      }
-    }
   }
 
   /// Remove stray views from view hierarcy.


### PR DESCRIPTION
This PR refactors how view cleanup is handled, it is now a concern of `FamilyScrollView` instead of the view controller handling that logic. The space manager also got some spring cleaning mechanisms in order to clean up views that don't have a super view.