### PR TITLE
Optimize layout algoritm

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.10"
+  s.version          = "0.5.11"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Reduces the number of times that `layoutViews` is invoked dramatically by opting out from triggering observers when the scroll view is scrolling.

Additional checks for not setting the same frame or bounds twice is also implemented.