### PR TITLE
Set .contentInsetAdjustmentBehavior to never on scroll views

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.11"
+  s.version          = "0.5.12"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -96,6 +96,10 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       scrollView.contentView.addSubview(childController.view)
     }
 
+    if #available(iOS 11.0, *) {
+      (childController.view as? UIScrollView)?.contentInsetAdjustmentBehavior = .never
+    }
+
     childController.didMove(toParentViewController: self)
     registry[childController] = (childController.view, observe(childController))
     scrollView.purgeWrapperViews()
@@ -138,6 +142,11 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     childController.view.frame.size = .zero
     childController.view.isHidden = true
     let childView = closure(childController)
+
+    if #available(iOS 11.0, *) {
+      (childView as? UIScrollView)?.contentInsetAdjustmentBehavior = .never
+    }
+
     addView(childView, customSpacing: spacing)
     childController.didMove(toParentViewController: self)
     registry[childController] = (childView, observe(childController))


### PR DESCRIPTION
If underlaying scroll views get adjusted, the user can get a stutter in the scroll experience. Disabling this when adding a custom view as a child view controller helps fix this issue.