### PR TITLE
Improve handling rotation

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.12"
+  s.version          = "0.5.13"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -90,7 +90,7 @@ public final class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
   /// - Parameter scrollView: The scroll view that should be configured
   ///                         and observed.
   func didAddScrollViewToContainer(_ scrollView: UIScrollView) {
-    scrollView.autoresizingMask = UIViewAutoresizing()
+    scrollView.autoresizingMask = [.flexibleWidth]
 
     guard contentView.subviews.index(of: scrollView) != nil else {
       return
@@ -352,6 +352,10 @@ public final class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
       }
 
       frame.size.height = newHeight
+
+      if frame.size.width != self.frame.width {
+        frame.size.width = self.frame.width
+      }
 
       if scrollView.frame != frame {
         scrollView.frame = frame

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -46,13 +46,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  /// Called to notify the view controller that its view is about to layout its subviews.
-  open override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    scrollView.frame = view.bounds
-    scrollView.contentView.frame = scrollView.bounds
-  }
-
   /// Configure constraints for the scroll view.
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -116,7 +109,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     scrollView.contentView.addSubview(childController.view)
     childController.didMove(toParentViewController: self)
     childController.view.translatesAutoresizingMaskIntoConstraints = true
-    childController.view.autoresizingMask = []
+    childController.view.frame.size.width = view.frame.size.width
+    childController.view.autoresizingMask = [.flexibleWidth]
     childController.view.frame.size.height = height
     registry[childController] = (childController.view, observe(childController))
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -60,16 +60,16 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       constraints.append(contentsOf: [
         scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
         scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-        scrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
-        scrollView.rightAnchor.constraint(equalTo: view.rightAnchor)
+        scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+        scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
       ])
     } else {
       if #available(iOS 9.0, *) {
         constraints.append(contentsOf: [
           scrollView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor),
           scrollView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
-          scrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
-          scrollView.rightAnchor.constraint(equalTo: view.rightAnchor)
+          scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+          scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
       }
     }

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -36,6 +36,7 @@ final class FamilyWrapperView: UIScrollView {
       }
     }
 
+    view.autoresizingMask = [.flexibleWidth]
     addSubview(view)
     alwaysBounceVertical = true
     clipsToBounds = true


### PR DESCRIPTION
This PR improves how the framework handles device rotation.
Child view controllers wrapped inside the `FamilyScrollView` will now use auto resizing mask set to `.flexibleWidth` and the layout algorithm will correct the width of the views if they don't correspond with `FamilyScrollView`´s frame.