### PR TITLE
Fix scrolling bug with single view controller

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.5.15"
+  s.version          = "0.5.16"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/FamilyTests/iOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/iOS/FamilyScrollViewTests.swift
@@ -16,6 +16,25 @@ class FamilyScrollViewTests: XCTestCase {
     superview.subviews.forEach { $0.removeFromSuperview() }
   }
 
+  // Content observers should not trigger if there is only one scroll view.
+  func testContentSizeObserverWithSingleScrollView() {
+    scrollView.frame.size.width = FamilyScrollViewTests.mockFrame.size.width
+    superview.addSubview(scrollView)
+    var size = CGSize(width: 500, height: 250)
+    let mockedScrollView = UIScrollView(frame: CGRect(origin: .zero, size: size))
+    mockedScrollView.contentSize = size
+
+    scrollView.contentView.addSubview(mockedScrollView)
+    scrollView.layoutViews()
+
+    XCTAssertEqual(mockedScrollView.frame, CGRect(origin: .zero, size: size))
+
+    // Check that the layout algorithm is invoked if the views frame changes.
+    size.height = 1500
+    mockedScrollView.contentSize = size
+    XCTAssertNotEqual(scrollView.contentSize, size)
+  }
+
   func testContentSizeObserver() {
     scrollView.frame.size.width = FamilyScrollViewTests.mockFrame.size.width
     superview.addSubview(scrollView)
@@ -23,6 +42,7 @@ class FamilyScrollViewTests: XCTestCase {
     let mockedScrollView = UIScrollView(frame: CGRect(origin: .zero, size: size))
     mockedScrollView.contentSize = size
 
+    scrollView.contentView.addSubview(UIScrollView())
     scrollView.contentView.addSubview(mockedScrollView)
     scrollView.layoutViews()
 

--- a/Sources/iOS+tvOS/Classes/FamilyContentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyContentView.swift
@@ -1,11 +1,16 @@
 import UIKit
 
+protocol FamilyContentViewDelegate: class {
+  func familyContentView(_ view: FamilyContentView, didAddScrollView scrollView: UIScrollView)
+}
+
 /// This classes acts as a view container for `FamilyScrollView`.
 /// It is used to wrap views that don't inherit from `UIScrollView`
 /// in `FamilyWrapperView`'s. This is done so that the `FamilyScrollView`
 /// only needs to take `UIScrollView` based views into account when performing
 /// its layout algorithm.
-final public class FamilyContentView: UIView {
+public class FamilyContentView: UIView {
+  weak var delegate: FamilyContentViewDelegate?
   weak var familyScrollView: FamilyScrollView?
 
   /// Convenience methods to return all subviews as scroll view.
@@ -34,18 +39,10 @@ final public class FamilyContentView: UIView {
     }
 
     super.addSubview(subview)
-  }
 
-  /// Tells the view that a subview was added.
-  /// The view will be registered in `FamilyScrollView`'s hierarchy,
-  /// which in turn registers observers in order to get fluid & smooth scrolling
-  /// when using a `FamilyScrollView`.
-  ///
-  /// - Parameter subview: The view that got added as a subview.
-  override open func didAddSubview(_ subview: UIView) {
-    if let scrollView = subview as? UIScrollView {
-      familyScrollView?.didAddScrollViewToContainer(scrollView)
-    }
+    guard let scrollView = subview as? UIScrollView else { return }
+
+    delegate?.familyContentView(self, didAddScrollView: scrollView)
   }
 
   /// Tells the view that a subview is about to be removed.

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -3,7 +3,7 @@ import UIKit
 /// This class is used to wrap views in `FamilyContentView` that don't inherit
 /// from `UIScrollView`. This is done to ensure that the user gets a fluid and
 /// smooth scrolling experience when scrolling in a `FamilyScrollView`.
-final class FamilyWrapperView: UIScrollView {
+class FamilyWrapperView: UIScrollView {
   weak var parentContentView: FamilyContentView?
   /// The wrapped view
   var view: UIView


### PR DESCRIPTION
Fixes a bug that the underlying scroll view couldn't be scrolled if there was only one view controller.

Now it will opt-out of doing proxy scrolling if there is only one view controller added. This is done because of performance. There is no need to invoke the layout algorithm if there is only one scroll view in the list of views.