### PR TITLE
Improve mac os implementation

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.6.0"
+  s.version          = "0.6.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/FamilyTests/macOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/macOS/FamilyScrollViewTests.swift
@@ -56,6 +56,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + scrollView.spacing * 2), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + scrollView.spacing * 3),
                                                    size: CGSize(width: size.width, height: size.height - scrollView.spacing * 3)))
+    scrollView.layout()
     XCTAssertEqual(scrollView.documentView?.frame.size.height, 1040)
 
     scrollView.spacing = 0
@@ -69,6 +70,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + 10), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + 20),
                                                    size: CGSize(width: size.width, height: size.height - 20)))
+    scrollView.layout()
     XCTAssertEqual(scrollView.documentView?.frame.size.height, 1020)
 
     scrollView.setCustomSpacing(0, after: mockedScrollView1)
@@ -77,6 +79,7 @@ class FamilyScrollViewTests: XCTestCase {
 
     scrollView.contentOffset.y = 250
     scrollView.layoutViews()
+    scrollView.layout()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
@@ -85,6 +88,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(scrollView.documentView?.frame.size.height, 1000)
 
     scrollView.contentOffset.y = 500
+    scrollView.layout()
     scrollView.layoutViews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))

--- a/FamilyTests/macOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/macOS/FamilyViewControllerTests.swift
@@ -68,9 +68,11 @@ class FamilyViewControllerTests: XCTestCase {
     wrapperView = (subviews[2] as? FamilyWrapperView)
     XCTAssertEqual(wrapperView?.documentView, thirdViewController.view)
 
+    familyViewController.scrollView.layout()
     familyViewController.scrollView.layoutViews(withDuration: 0)
     XCTAssertEqual(familyViewController.scrollView.documentView?.frame.size.height, 1500)
     secondViewController.view.isHidden = true
+    familyViewController.scrollView.layout()
     XCTAssertEqual(familyViewController.scrollView.documentView?.frame.size.height, 1000)
   }
 

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -40,10 +40,7 @@ public class FamilyScrollView: NSScrollView {
 
   public func layoutViews(withDuration duration: CFTimeInterval? = nil,
                           excludeOffscreenViews: Bool = true) {
-    defer { computeContentSize() }
-    if layoutIsRunning {
-      return
-    }
+    guard !layoutIsRunning else { return }
 
     if let duration = duration, duration > 0 {
       NSAnimationContext.current.duration = duration
@@ -128,6 +125,7 @@ public class FamilyScrollView: NSScrollView {
   public override func layout() {
     layoutViews()
     super.layout()
+    computeContentSize()
   }
 
   public func customSpacing(after view: View) -> CGFloat {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -42,10 +42,14 @@ public class FamilyScrollView: NSScrollView {
                           excludeOffscreenViews: Bool = true) {
     guard !layoutIsRunning else { return }
 
+    CATransaction.begin()
+    defer { CATransaction.commit() }
+
     if let duration = duration, duration > 0 {
       NSAnimationContext.current.duration = duration
       NSAnimationContext.current.allowsImplicitAnimation = true
     } else if isScrolling {
+      CATransaction.setDisableActions(true)
       NSAnimationContext.current.duration = 0.0
       NSAnimationContext.current.allowsImplicitAnimation = false
     }


### PR DESCRIPTION
- This improves scrolling performance as it won't calculate the content size for the document view when the content offset of the scroll view changes. This is now handled when `layout` is called.
- Adds `CATransaction` to apply atomic updates to the layout algorithm. This fixes rendering issues that can occur when the user switches direction when scrolling.