### PR TITLE
Exclude views with alpha value 0.0 from layout algorithm

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.6.1"
+  s.version          = "0.6.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -157,10 +157,16 @@ public class FamilyScrollView: NSScrollView {
     subviewsInLayoutOrder = filteredSubviews
   }
 
+  private func validateScrollView(_ scrollView: NSScrollView) -> Bool {
+    guard scrollView.documentView != nil else { return false }
+
+    return scrollView.documentView?.isHidden == false && (scrollView.documentView?.alphaValue ?? 1.0) > CGFloat(0.0)
+  }
+
   private func runLayoutSubviewsAlgorithm(excludeOffscreenViews: Bool = true) {
     var yOffsetOfCurrentSubview: CGFloat = 0.0
     var offset = 0
-    for scrollView in subviewsInLayoutOrder where scrollView.documentView != nil && scrollView.documentView?.isHidden == false && (scrollView.documentView?.alphaValue ?? 1.0) > CGFloat(0.0) {
+    for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
       var shouldResize: Bool = true
       let contentSize: CGSize = contentSizeForView(scrollView.documentView!, shouldResize: &shouldResize)
       var frame = scrollView.frame
@@ -247,7 +253,7 @@ public class FamilyScrollView: NSScrollView {
 
   private func computeContentSize() {
     let computedHeight: CGFloat = subviewsInLayoutOrder
-      .filter({ $0.documentView?.isHidden == false || ($0.documentView?.alphaValue ?? 1.0) > 0.0 })
+      .filter({ validateScrollView($0) })
       .reduce(0, { $0 + ($1.documentView?.frame.size.height ?? 0) + spaceManager.customSpacing(after: ($1 as? FamilyWrapperView)?.view ?? $1) })
     let minimumContentHeight = bounds.height
     var height = fmax(computedHeight, minimumContentHeight)

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -160,7 +160,7 @@ public class FamilyScrollView: NSScrollView {
   private func runLayoutSubviewsAlgorithm(excludeOffscreenViews: Bool = true) {
     var yOffsetOfCurrentSubview: CGFloat = 0.0
     var offset = 0
-    for scrollView in subviewsInLayoutOrder where scrollView.documentView != nil && scrollView.documentView?.isHidden == false {
+    for scrollView in subviewsInLayoutOrder where scrollView.documentView != nil && scrollView.documentView?.isHidden == false && (scrollView.documentView?.alphaValue ?? 1.0) > CGFloat(0.0) {
       var shouldResize: Bool = true
       let contentSize: CGSize = contentSizeForView(scrollView.documentView!, shouldResize: &shouldResize)
       var frame = scrollView.frame
@@ -247,7 +247,7 @@ public class FamilyScrollView: NSScrollView {
 
   private func computeContentSize() {
     let computedHeight: CGFloat = subviewsInLayoutOrder
-      .filter({ $0.documentView?.isHidden == false })
+      .filter({ $0.documentView?.isHidden == false || ($0.documentView?.alphaValue ?? 1.0) > 0.0 })
       .reduce(0, { $0 + ($1.documentView?.frame.size.height ?? 0) + spaceManager.customSpacing(after: ($1 as? FamilyWrapperView)?.view ?? $1) })
     let minimumContentHeight = bounds.height
     var height = fmax(computedHeight, minimumContentHeight)

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -46,8 +46,17 @@ public class FamilyScrollView: NSScrollView {
     defer { CATransaction.commit() }
 
     if let duration = duration, duration > 0 {
-      NSAnimationContext.current.duration = duration
-      NSAnimationContext.current.allowsImplicitAnimation = true
+      layoutIsRunning = true
+      NSAnimationContext.runAnimationGroup({ (context) in
+        context.duration = duration
+        context.allowsImplicitAnimation = true
+        runLayoutSubviewsAlgorithm(excludeOffscreenViews: excludeOffscreenViews)
+      }, completionHandler: { [weak self] in
+        self?.computeContentSize()
+        self?.runLayoutSubviewsAlgorithm()
+        self?.layoutIsRunning = false
+      })
+      return
     } else if isScrolling {
       CATransaction.setDisableActions(true)
       NSAnimationContext.current.duration = 0.0

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -5,6 +5,7 @@ class FamilyWrapperView: NSScrollView {
   var isScrolling: Bool = false
   var view: NSView
   private var frameObserver: NSKeyValueObservation?
+  private var alphaObserver: NSKeyValueObservation?
   private var hiddenObserver: NSKeyValueObservation?
 
   open override var verticalScroller: NSScroller? {
@@ -27,6 +28,13 @@ class FamilyWrapperView: NSScrollView {
         self.layoutViews()
       }
     })
+
+    self.alphaObserver = view.observe(\.alphaValue, options: [.initial, .new, .old]) { [weak self] (_, value) in
+      if value.newValue != value.oldValue, let newValue = value.newValue {
+        self?.alphaValue = newValue
+        self?.layoutViews()
+      }
+    }
 
     self.hiddenObserver = view.observe(\.isHidden, options: [.initial, .new, .old]) { [weak self] (_, value) in
       if value.newValue != value.oldValue, let newValue = value.newValue {
@@ -67,7 +75,7 @@ class FamilyWrapperView: NSScrollView {
       if view is NSCollectionView {
         let delay = NSAnimationContext.current.duration
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-          familyScrollView.layoutViews(withDuration: delay)
+          familyScrollView.layoutViews(withDuration: 0.0)
         }
       } else {
         familyScrollView.layoutViews(withDuration: NSAnimationContext.current.duration)


### PR DESCRIPTION
This PR improves the layout algorithm by excluding views with alpha value at 0.0.
That way you can animate views in and out of the view hierarchy.