### PR TITLE
Refactor FamilyWrapperView

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.6.2"
+  s.version          = "0.6.3"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -158,6 +158,11 @@ public class FamilyScrollView: NSScrollView {
     layoutViews(withDuration: 0.0, excludeOffscreenViews: false)
   }
 
+  func wrapperViewDidChangeFrame() {
+    runLayoutSubviewsAlgorithm()
+    computeContentSize()
+  }
+
   // MARK: - Private methods
 
   private func rebuildSubviewsInLayoutOrder(exceptSubview: View? = nil) {


### PR DESCRIPTION
Fixes a scroll bug on macOS where the content size did not calculate properly because wrapped view frame updates
was ignored. Now these kind of updates are forced which makes the `contentSize` valid.

- Improves layoutViews with new force label
- Force updates the family scroll view when a wrapped view changes frame
- Adds `wrapperViewDidChangeFrame` to FamilyScrollView, this is invoked to force the layout algorithm to run