### PR TITLE
Remove layout implementation on FamilyWrapperView to fix recursion on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.6.3"
+  s.version          = "0.6.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -45,11 +45,6 @@ class FamilyWrapperView: NSScrollView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  override func layout() {
-    super.layout()
-    layoutViews()
-  }
-
   override func scrollWheel(with event: NSEvent) {
     if event.scrollingDeltaX != 0.0 && view.frame.size.width > frame.size.width {
       super.scrollWheel(with: event)

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -17,6 +17,7 @@ class FamilyWrapperView: NSScrollView {
     self.view = wrappedView
     super.init(frame: frameRect)
     self.contentView = NSClipView()
+    self.contentView.translatesAutoresizingMaskIntoConstraints = false
     self.documentView = wrappedView
     self.hasHorizontalScroller = true
     self.hasVerticalScroller = false


### PR DESCRIPTION
This PR fixes a layout recursion in the wrapper view on macOS