### PR TITLE
Fix layout glitch when dynamically adding views

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.6.4"
+  s.version          = "0.6.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/FamilyTests/macOS/FamilyContentViewTests.swift
+++ b/FamilyTests/macOS/FamilyContentViewTests.swift
@@ -24,6 +24,7 @@ class FamilyContentViewTests: XCTestCase {
 
   func testAddingRegularViewToContentView() {
     let size = CGSize(width: 200, height: 200)
+    scrollView.frame.size = size
     let regularView = NSView(frame: CGRect(origin: .zero, size: size))
 
     contentView.addSubview(regularView)
@@ -65,11 +66,8 @@ class FamilyContentViewTests: XCTestCase {
   func testLayoutMethod() {
     let size = CGSize(width: 200, height: 200)
     let view = NSView(frame: CGRect(origin: .zero, size: size))
-
-    contentView.addSubview(view)
-
     XCTAssertFalse(scrollView.didLayout)
-    contentView.scroll(.zero)
+    contentView.addSubview(view)
     XCTAssertTrue(scrollView.didLayout)
   }
 }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -133,6 +133,7 @@ public class FamilyScrollView: NSScrollView {
         subviewsInLayoutOrder.append(scrollView)
       }
     }
+    layoutViews()
   }
 
   public override func layout() {


### PR DESCRIPTION
Add call to layoutViews() when new views are added to the scroll view. This will trigger the layout algorithm to layout the views properly.