### PR TITLE
Refactor the layout algorithm on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.6.8"
+  s.version          = "0.7.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD02F56721B43E5E006ECE48 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
+		BD02F56921B43E7F006ECE48 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
 		BD0FCCD620794AFA00D813EC /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
 		BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
 		BD2236E32034B12A00C465E4 /* NSScrollView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */; };
@@ -79,6 +81,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD02F56621B43E5E006ECE48 /* FamilyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyCache.swift; sourceTree = "<group>"; };
+		BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyCacheEntry.swift; sourceTree = "<group>"; };
 		BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScrollView+Extensions.swift"; sourceTree = "<group>"; };
 		BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyWrapperView.swift; sourceTree = "<group>"; };
 		BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };
@@ -191,10 +195,12 @@
 		BD2236E02034B10F00C465E4 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */,
-				BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */,
-				BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */,
+				BD02F56621B43E5E006ECE48 /* FamilyCache.swift */,
+				BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */,
 				BD4C7FE320349B030037D3E5 /* FamilyContentView.swift */,
+				BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */,
+				BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */,
+				BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -696,6 +702,8 @@
 				BD44980E2034A09700ED83D4 /* FamilyWrapperView.swift in Sources */,
 				BD7629BF20349CA300C917BB /* FamilyFriendly.swift in Sources */,
 				BD4C7FE420349B030037D3E5 /* FamilyContentView.swift in Sources */,
+				BD02F56721B43E5E006ECE48 /* FamilyCache.swift in Sources */,
+				BD02F56921B43E7F006ECE48 /* FamilyCacheEntry.swift in Sources */,
 				BD0FCCD620794AFA00D813EC /* FamilySpaceManager.swift in Sources */,
 				BD4C7FE020349AA10037D3E5 /* FamilyViewController.swift in Sources */,
 				BD7629BB20349C2C00C917BB /* TypeAlias.swift in Sources */,

--- a/FamilyTests/macOS/FamilyContentViewTests.swift
+++ b/FamilyTests/macOS/FamilyContentViewTests.swift
@@ -8,12 +8,10 @@ class FamilyContentViewTests: XCTestCase {
 
 
     override func layoutViews(withDuration duration: CFTimeInterval? = nil,
-                              force: Bool = false,
-                              excludeOffscreenViews: Bool = true) {
+                              force: Bool = false) {
       super.layoutViews(
         withDuration: duration,
-        force: force,
-        excludeOffscreenViews: excludeOffscreenViews
+        force: force
       )
       didLayout = true
     }

--- a/FamilyTests/macOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/macOS/FamilyScrollViewTests.swift
@@ -81,7 +81,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.layoutViews()
     scrollView.layout()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
@@ -92,7 +92,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.layoutViews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
 
@@ -101,7 +101,7 @@ class FamilyScrollViewTests: XCTestCase {
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
-    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
+    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
 
     let rect = CGRect(origin: .zero, size: CGSize(width: 500, height: 1250))

--- a/Sources/macOS/Classes/FamilyCache.swift
+++ b/Sources/macOS/Classes/FamilyCache.swift
@@ -1,0 +1,20 @@
+import Cocoa
+
+class FamilyCache: NSObject {
+  var contentSize: CGSize = .zero
+  var storage = [NSView: FamilyCacheEntry]()
+  var isEmpty: Bool { return storage.isEmpty }
+  override init() {}
+
+  func add(entry: FamilyCacheEntry) {
+    storage[entry.view] = entry
+  }
+
+  func entry(for view: NSView) -> FamilyCacheEntry? {
+    return storage[view]
+  }
+
+  func clear() {
+    storage.removeAll()
+  }
+}

--- a/Sources/macOS/Classes/FamilyCacheEntry.swift
+++ b/Sources/macOS/Classes/FamilyCacheEntry.swift
@@ -1,0 +1,13 @@
+import Cocoa
+
+class FamilyCacheEntry: NSObject {
+  var view: NSView
+  var origin: CGPoint
+  var contentSize: CGSize
+
+  init(view: NSView, origin: CGPoint, contentSize: CGSize) {
+    self.view = view
+    self.origin = origin
+    self.contentSize = contentSize
+  }
+}

--- a/Sources/macOS/Classes/FamilyContentView.swift
+++ b/Sources/macOS/Classes/FamilyContentView.swift
@@ -32,7 +32,8 @@ public class FamilyContentView: NSView {
   }
 
   override public func willRemoveSubview(_ subview: NSView) {
-    familyScrollView?.willRemoveSubview(subview)
+    super.willRemoveSubview(subview)
+    familyScrollView?.didRemoveScrollViewToContainer(subview)
   }
 
   override public func scroll(_ point: NSPoint) {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -37,8 +37,8 @@ public class FamilyScrollView: NSScrollView {
   public var spacing: CGFloat {
     get { return spaceManager.spacing }
     set {
-      cache.clear()
       spaceManager.spacing = newValue
+      cache.clear()
     }
   }
   var layoutIsRunning: Bool = false

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -266,14 +266,14 @@ public class FamilyScrollView: NSScrollView {
       }
       computeContentSize()
     } else {
-      for (offset, scrollView) in subviewsInLayoutOrder.enumerated() where validateScrollView(scrollView) {
+      for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
         let documentView = scrollView.documentView!
         guard let entry = cache.entry(for: documentView) else { return }
         let currentOffset = self.contentOffset.y + contentView.contentInsets.top
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
-        if self.contentOffset.y <= entry.origin.y {
+        if self.contentOffset.y < entry.origin.y {
           contentOffset.y = 0
           frame.origin.y = floor(entry.origin.y)
         } else {
@@ -282,7 +282,7 @@ public class FamilyScrollView: NSScrollView {
         }
 
         let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)
-        let remainingContentHeight = fmax(entry.contentSize.height + entry.origin.y, 0.0)
+        let remainingContentHeight = fmax(entry.contentSize.height - contentOffset.y, 0.0)
         let newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
         let maxOffset = self.contentOffset.y + self.frame.size.height
         let documentHeight = self.documentView!.frame.size.height

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -271,6 +271,7 @@ public class FamilyScrollView: NSScrollView {
         guard let entry = cache.entry(for: documentView) else { return }
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
+        let currentOffset = self.contentOffset.y + contentView.contentInsets.top
 
         if self.contentOffset.y < entry.origin.y {
           contentOffset.y = 0
@@ -282,9 +283,16 @@ public class FamilyScrollView: NSScrollView {
 
         let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)
         let remainingContentHeight = fmax(entry.contentSize.height - contentOffset.y, 0.0)
-        let newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
         let maxOffset = self.contentOffset.y + self.frame.size.height
         let documentHeight = self.documentView!.frame.size.height
+        var newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
+
+        if newHeight == 0 {
+          newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
+        }
+
+        // Reached the top
+        guard currentOffset >= 0 else { return }
 
         // Reached the end
         guard maxOffset <= documentHeight else { return }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -1,36 +1,5 @@
 import Cocoa
 
-class FamilyCache: NSObject {
-  var contentSize: CGSize = .zero
-  var cache = [NSView: CacheEntry]()
-  var isEmpty: Bool { return cache.isEmpty }
-  override init() {}
-
-  func add(entry: CacheEntry) {
-    cache[entry.view] = entry
-  }
-
-  func entry(for view: NSView) -> CacheEntry? {
-    return cache[view]
-  }
-
-  func clear() {
-    cache.removeAll()
-  }
-}
-
-class CacheEntry: NSObject {
-  var view: NSView
-  var origin: CGPoint
-  var contentSize: CGSize
-
-  init(view: NSView, origin: CGPoint, contentSize: CGSize) {
-    self.view = view
-    self.origin = origin
-    self.contentSize = contentSize
-  }
-}
-
 public class FamilyScrollView: NSScrollView {
   public override var isFlipped: Bool { return true }
   public lazy var familyContentView: FamilyContentView = .init()
@@ -263,7 +232,7 @@ public class FamilyScrollView: NSScrollView {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
         yOffsetOfCurrentSubview += contentSize.height + spaceManager.customSpacing(after: view)
         offset += 1
-        cache.add(entry: CacheEntry.init(view: scrollView.documentView!, origin: frame.origin, contentSize: contentSize))
+        cache.add(entry: FamilyCacheEntry(view: scrollView.documentView!, origin: frame.origin, contentSize: contentSize))
       }
       computeContentSize()
     } else {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -288,7 +288,7 @@ public class FamilyScrollView: NSScrollView {
         let documentHeight = self.documentView!.frame.size.height
 
         // Reached the top
-        guard currentOffset >= 0 else { return }
+        guard currentOffset > 0 else { return }
 
         // Reached the end
         guard maxOffset <= documentHeight else { return }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -269,7 +269,6 @@ public class FamilyScrollView: NSScrollView {
       for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
         let documentView = scrollView.documentView!
         guard let entry = cache.entry(for: documentView) else { return }
-        let currentOffset = self.contentOffset.y + contentView.contentInsets.top
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
@@ -286,9 +285,6 @@ public class FamilyScrollView: NSScrollView {
         let newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
         let maxOffset = self.contentOffset.y + self.frame.size.height
         let documentHeight = self.documentView!.frame.size.height
-
-        // Reached the top
-        guard currentOffset > 0 else { return }
 
         // Reached the end
         guard maxOffset <= documentHeight else { return }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -178,6 +178,7 @@ public class FamilyScrollView: NSScrollView {
 
   public func setCustomSpacing(_ spacing: CGFloat, after view: View) {
     spaceManager.setCustomSpacing(spacing, after: view)
+    cache.clear()
   }
 
   public override func scrollWheel(with event: NSEvent) {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -272,7 +272,7 @@ public class FamilyScrollView: NSScrollView {
       }
       computeContentSize()
     } else {
-      for (offset, scrollView) in subviewsInLayoutOrder.enumerated() where validateScrollView(scrollView) {
+      for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
         guard let entry = cache.entry(for: scrollView.documentView!) else { return }
 
         var frame = scrollView.frame

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -268,18 +268,16 @@ public class FamilyScrollView: NSScrollView {
       computeContentSize()
     } else {
       let currentOffset = self.contentOffset.y + contentView.contentInsets.top
-      let maxOffset = self.contentOffset.y + self.frame.size.height
       let documentHeight = self.documentView!.frame.size.height
 
       // Reached the top
       guard currentOffset >= 0 else { return }
 
       // Reached the end
-      guard maxOffset <= documentHeight else { return }
+      guard self.documentVisibleRect.maxY <= documentHeight else { return }
 
       for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
-        let documentView = scrollView.documentView!
-        guard let entry = cache.entry(for: documentView) else { continue }
+        guard let entry = cache.entry(for: scrollView.documentView!) else { continue }
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -49,12 +49,8 @@ public class FamilyScrollView: NSScrollView {
     self.documentView = familyContentView
     self.drawsBackground = false
     self.familyContentView.familyScrollView = self
-
-    scrollerStyle = .legacy
-
     configureObservers()
     hasVerticalScroller = true
-
     contentView.postsBoundsChangedNotifications = true
     familyContentView.autoresizingMask = [.width]
   }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -286,16 +286,19 @@ public class FamilyScrollView: NSScrollView {
         let remainingContentHeight = fmax(entry.contentSize.height + entry.origin.y - self.contentOffset.y, 0.0)
         let newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
 
-        if self.contentOffset.y + self.frame.size.height <= self.documentView!.frame.size.height {
+        let currentOffset = self.contentOffset.y + self.frame.size.height
+        let documentHeight = self.documentView!.frame.size.height
+
+        if currentOffset <= documentHeight {
           scrollView.contentView.scroll(contentOffset)
           scrollView.frame.origin.y = frame.origin.y
-          scrollView.frame.size.height = newHeight
+          if scrollView.frame.size.height != newHeight {
+            scrollView.frame.size.height = newHeight
+          }
         }
       }
     }
   }
-
-  @objc func injected() {}
 
   private func contentSizeForView(_ view: NSView, shouldResize: inout Bool) -> CGSize {
     var contentSize: CGSize = .zero

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -68,7 +68,6 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     super.addChild(childController)
     view.addSubview(childController.view)
     childController.view.frame.size = .zero
-    childController.view.isHidden = true
     let childView = closure(childController)
     addView(childView, customSpacing: spacing)
     registry[childController] = childView

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -67,8 +67,8 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   public func addChild<T: ViewController>(_ childController: T, customSpacing spacing: CGFloat? = nil, view closure: (T) -> View) {
     super.addChild(childController)
     view.addSubview(childController.view)
-    childController.view.frame.size = .zero
-    childController.view.isHidden = true
+    childController.view.frame.size = .init(width: 1, height: 1)
+//    childController.view.isHidden = true
     let childView = closure(childController)
     addView(childView, customSpacing: spacing)
     registry[childController] = childView

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -67,8 +67,8 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   public func addChild<T: ViewController>(_ childController: T, customSpacing spacing: CGFloat? = nil, view closure: (T) -> View) {
     super.addChild(childController)
     view.addSubview(childController.view)
-    childController.view.frame.size = .init(width: 1, height: 1)
-//    childController.view.isHidden = true
+    childController.view.frame.size = .zero
+    childController.view.isHidden = true
     let childView = closure(childController)
     addView(childView, customSpacing: spacing)
     registry[childController] = childView

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -26,7 +26,7 @@ class FamilyWrapperView: NSScrollView {
 
     self.frameObserver = wrappedView.observe(\.frame, options: [.new, .old], changeHandler: { [weak self] (_, value) in
       guard value.newValue != value.oldValue else { return }
-      self?.layoutViews(force: true)
+      self?.layoutViews(from: value.oldValue, to: value.newValue)
     })
 
     self.alphaObserver = view.observe(\.alphaValue, options: [.initial, .new, .old]) { [weak self] (_, value) in
@@ -57,9 +57,9 @@ class FamilyWrapperView: NSScrollView {
       !(event.phase == .ended || event.momentumPhase == .ended)
   }
 
-  func layoutViews(force: Bool = false) {
-    if force {
-      (enclosingScrollView as? FamilyScrollView)?.wrapperViewDidChangeFrame()
+  func layoutViews(from fromValue: CGRect? = nil, to toValue: CGRect? = nil) {
+    if let fromValue = fromValue, let toValue = toValue {
+      (enclosingScrollView as? FamilyScrollView)?.wrapperViewDidChangeFrame(from: fromValue, to: toValue)
       return
     }
 

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -32,12 +32,14 @@ class FamilyWrapperView: NSScrollView {
     self.alphaObserver = view.observe(\.alphaValue, options: [.initial, .new, .old]) { [weak self] (_, value) in
       guard value.newValue != value.oldValue, let newValue = value.newValue else { return }
       self?.alphaValue = newValue
+      (self?.enclosingScrollView as? FamilyScrollView)?.cache.clear()
       self?.layoutViews()
     }
 
     self.hiddenObserver = view.observe(\.isHidden, options: [.initial, .new, .old]) { [weak self] (_, value) in
       guard value.newValue != value.oldValue, let newValue = value.newValue else { return }
       self?.isHidden = newValue
+      (self?.enclosingScrollView as? FamilyScrollView)?.cache.clear()
       self?.layoutViews()
     }
   }


### PR DESCRIPTION
This PR refactors the layout algorithm on macOS to increase performance. It does this by introducing an additional more lightweight algorithm that uses the cached results from the old algorithm.

So it works like this; if there are no cached results, it will invoke the old algorithm and create an internal cache from the results of that algorithm. The next layout pass will then use the results of the cache in order to layout the views in linear order. Cache invalidation happens if any arguments tied to the algorithm is changed, like changing the spacing between views. The cache is also invalidated when views are added or remove from the view hierarchy. Last but not least, if a view changes its high, the cache is also invalidated and then re-cached.