### PR TITLE
Improve scrolling using keyboard events on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.7.1"
+  s.version          = "0.7.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -16,10 +16,10 @@
 		BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */; };
 		BD4C7FE020349AA10037D3E5 /* FamilyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */; };
 		BD4C7FE220349ACE0037D3E5 /* FamilyScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */; };
-		BD4C7FE420349B030037D3E5 /* FamilyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FE320349B030037D3E5 /* FamilyContentView.swift */; };
+		BD4C7FE420349B030037D3E5 /* FamilyDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FE320349B030037D3E5 /* FamilyDocumentView.swift */; };
 		BD535E162079269200AA2EC4 /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
-		BD5A803C2030A9D9006A5EBB /* FamilyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80362030A9D9006A5EBB /* FamilyContentView.swift */; };
-		BD5A803D2030A9D9006A5EBB /* FamilyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80362030A9D9006A5EBB /* FamilyContentView.swift */; };
+		BD5A803C2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80362030A9D9006A5EBB /* FamilyDocumentView.swift */; };
+		BD5A803D2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80362030A9D9006A5EBB /* FamilyDocumentView.swift */; };
 		BD5A803E2030A9D9006A5EBB /* FamilyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80372030A9D9006A5EBB /* FamilyViewController.swift */; };
 		BD5A803F2030A9D9006A5EBB /* FamilyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80372030A9D9006A5EBB /* FamilyViewController.swift */; };
 		BD5A80402030A9D9006A5EBB /* FamilyWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80382030A9D9006A5EBB /* FamilyWrapperView.swift */; };
@@ -89,10 +89,10 @@
 		BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyClipView.swift; sourceTree = "<group>"; };
 		BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };
 		BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyScrollView.swift; sourceTree = "<group>"; };
-		BD4C7FE320349B030037D3E5 /* FamilyContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyContentView.swift; sourceTree = "<group>"; };
+		BD4C7FE320349B030037D3E5 /* FamilyDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyDocumentView.swift; sourceTree = "<group>"; };
 		BD535E142078DEFC00AA2EC4 /* Family.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Family.podspec; sourceTree = "<group>"; };
 		BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilySpaceManager.swift; sourceTree = "<group>"; };
-		BD5A80362030A9D9006A5EBB /* FamilyContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyContentView.swift; sourceTree = "<group>"; };
+		BD5A80362030A9D9006A5EBB /* FamilyDocumentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyDocumentView.swift; sourceTree = "<group>"; };
 		BD5A80372030A9D9006A5EBB /* FamilyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };
 		BD5A80382030A9D9006A5EBB /* FamilyWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyWrapperView.swift; sourceTree = "<group>"; };
 		BD5A80392030A9D9006A5EBB /* FamilyScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyScrollView.swift; sourceTree = "<group>"; };
@@ -199,7 +199,7 @@
 			children = (
 				BD02F56621B43E5E006ECE48 /* FamilyCache.swift */,
 				BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */,
-				BD4C7FE320349B030037D3E5 /* FamilyContentView.swift */,
+				BD4C7FE320349B030037D3E5 /* FamilyDocumentView.swift */,
 				BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */,
 				BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */,
 				BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */,
@@ -237,7 +237,7 @@
 		BD5A80352030A9D9006A5EBB /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				BD5A80362030A9D9006A5EBB /* FamilyContentView.swift */,
+				BD5A80362030A9D9006A5EBB /* FamilyDocumentView.swift */,
 				BD5A80372030A9D9006A5EBB /* FamilyViewController.swift */,
 				BD5A80382030A9D9006A5EBB /* FamilyWrapperView.swift */,
 				BD5A80392030A9D9006A5EBB /* FamilyScrollView.swift */,
@@ -645,7 +645,7 @@
 				BD5A80432030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
 				BD5A803F2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
 				BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */,
-				BD5A803D2030A9D9006A5EBB /* FamilyContentView.swift in Sources */,
+				BD5A803D2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80452030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629C020349CA300C917BB /* FamilyFriendly.swift in Sources */,
 			);
@@ -679,7 +679,7 @@
 				BD5A80422030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
 				BD5A803E2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
 				BD535E162079269200AA2EC4 /* FamilySpaceManager.swift in Sources */,
-				BD5A803C2030A9D9006A5EBB /* FamilyContentView.swift in Sources */,
+				BD5A803C2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80442030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629BE20349CA300C917BB /* FamilyFriendly.swift in Sources */,
 			);
@@ -704,7 +704,7 @@
 				BD2236E32034B12A00C465E4 /* NSScrollView+Extensions.swift in Sources */,
 				BD44980E2034A09700ED83D4 /* FamilyWrapperView.swift in Sources */,
 				BD7629BF20349CA300C917BB /* FamilyFriendly.swift in Sources */,
-				BD4C7FE420349B030037D3E5 /* FamilyContentView.swift in Sources */,
+				BD4C7FE420349B030037D3E5 /* FamilyDocumentView.swift in Sources */,
 				BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */,
 				BD02F56721B43E5E006ECE48 /* FamilyCache.swift in Sources */,
 				BD02F56921B43E7F006ECE48 /* FamilyCacheEntry.swift in Sources */,

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
 		BD2236E32034B12A00C465E4 /* NSScrollView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */; };
 		BD44980E2034A09700ED83D4 /* FamilyWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */; };
+		BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */; };
 		BD4C7FE020349AA10037D3E5 /* FamilyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */; };
 		BD4C7FE220349ACE0037D3E5 /* FamilyScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */; };
 		BD4C7FE420349B030037D3E5 /* FamilyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FE320349B030037D3E5 /* FamilyContentView.swift */; };
@@ -85,6 +86,7 @@
 		BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyCacheEntry.swift; sourceTree = "<group>"; };
 		BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScrollView+Extensions.swift"; sourceTree = "<group>"; };
 		BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyWrapperView.swift; sourceTree = "<group>"; };
+		BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyClipView.swift; sourceTree = "<group>"; };
 		BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };
 		BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyScrollView.swift; sourceTree = "<group>"; };
 		BD4C7FE320349B030037D3E5 /* FamilyContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyContentView.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */,
 				BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */,
 				BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */,
+				BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -702,6 +705,7 @@
 				BD44980E2034A09700ED83D4 /* FamilyWrapperView.swift in Sources */,
 				BD7629BF20349CA300C917BB /* FamilyFriendly.swift in Sources */,
 				BD4C7FE420349B030037D3E5 /* FamilyContentView.swift in Sources */,
+				BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */,
 				BD02F56721B43E5E006ECE48 /* FamilyCache.swift in Sources */,
 				BD02F56921B43E7F006ECE48 /* FamilyCacheEntry.swift in Sources */,
 				BD0FCCD620794AFA00D813EC /* FamilySpaceManager.swift in Sources */,

--- a/FamilyTests/iOS/FamilyContentViewTests.swift
+++ b/FamilyTests/iOS/FamilyContentViewTests.swift
@@ -3,20 +3,20 @@ import XCTest
 
 class FamilyContentViewTests: XCTestCase {
   var scrollView: FamilyScrollView!
-  var contentView: FamilyContentView!
+  var documentView: FamilyDocumentView!
 
   override func setUp() {
     scrollView = FamilyScrollView()
-    contentView = scrollView.contentView
+    documentView = scrollView.documentView
   }
 
   func testAddingRegularViewToContentView() {
     let size = CGSize(width: 200, height: 200)
     let regularView = UIView(frame: CGRect(origin: .zero, size: size))
 
-    contentView.addSubview(regularView)
+    documentView.addSubview(regularView)
 
-    guard let expectedView = contentView.subviews[0] as? FamilyWrapperView else {
+    guard let expectedView = documentView.subviews[0] as? FamilyWrapperView else {
       XCTFail("Unable to resolve wrapper view.")
       return
     }
@@ -27,7 +27,7 @@ class FamilyContentViewTests: XCTestCase {
 
     expectedView.removeFromSuperview()
 
-    XCTAssertTrue(contentView.subviews.isEmpty)
+    XCTAssertTrue(documentView.subviews.isEmpty)
   }
 
   func testAddingScrollViewToContentView() {
@@ -35,9 +35,9 @@ class FamilyContentViewTests: XCTestCase {
     let scrollView = UIScrollView(frame: CGRect(origin: .zero, size: size))
     scrollView.contentSize = size
 
-    contentView.addSubview(scrollView)
+    documentView.addSubview(scrollView)
 
-    guard let expectedView = contentView.subviews[0] as? UIScrollView else {
+    guard let expectedView = documentView.subviews[0] as? UIScrollView else {
       XCTFail("Unable to resolve wrapper view.")
       return
     }
@@ -48,6 +48,6 @@ class FamilyContentViewTests: XCTestCase {
 
     expectedView.removeFromSuperview()
 
-    XCTAssertTrue(contentView.subviews.isEmpty)
+    XCTAssertTrue(documentView.subviews.isEmpty)
   }
 }

--- a/FamilyTests/iOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/iOS/FamilyScrollViewTests.swift
@@ -23,8 +23,8 @@ class FamilyScrollViewTests: XCTestCase {
     let mockedScrollView = UIScrollView(frame: CGRect(origin: .zero, size: size))
     mockedScrollView.contentSize = size
 
-    scrollView.contentView.addSubview(UIScrollView())
-    scrollView.contentView.addSubview(mockedScrollView)
+    scrollView.documentView.addSubview(UIScrollView())
+    scrollView.documentView.addSubview(mockedScrollView)
     scrollView.layoutViews()
 
     XCTAssertEqual(mockedScrollView.frame, CGRect(origin: .zero, size: size))
@@ -40,12 +40,12 @@ class FamilyScrollViewTests: XCTestCase {
     let verticalCollectionViewLayout = UICollectionViewFlowLayout()
     verticalCollectionViewLayout.scrollDirection = .vertical
     let verticalCollectionView = UICollectionView(frame: frame, collectionViewLayout: verticalCollectionViewLayout)
-    scrollView.contentView.addSubview(verticalCollectionView)
+    scrollView.documentView.addSubview(verticalCollectionView)
 
     let horizontalCollectionViewLayout = UICollectionViewFlowLayout()
     horizontalCollectionViewLayout.scrollDirection = .horizontal
     let horizontalCollectionView = UICollectionView(frame: frame, collectionViewLayout: horizontalCollectionViewLayout)
-    scrollView.contentView.addSubview(horizontalCollectionView)
+    scrollView.documentView.addSubview(horizontalCollectionView)
 
     XCTAssertFalse(verticalCollectionView.isScrollEnabled)
     XCTAssertTrue(horizontalCollectionView.isScrollEnabled)
@@ -57,10 +57,10 @@ class FamilyScrollViewTests: XCTestCase {
   func testTableViews() {
     let frame = CGRect(origin: .zero, size: CGSize(width: 500, height: 200))
     let tableView = UITableView(frame: frame)
-    scrollView.contentView.addSubview(tableView)
+    scrollView.documentView.addSubview(tableView)
 
     let anotherTableView = UITableView(frame: frame)
-    scrollView.contentView.addSubview(anotherTableView)
+    scrollView.documentView.addSubview(anotherTableView)
 
     XCTAssertFalse(tableView.isScrollEnabled)
     XCTAssertFalse(anotherTableView.isScrollEnabled)
@@ -85,7 +85,7 @@ class FamilyScrollViewTests: XCTestCase {
 
     [mockedScrollView1, mockedScrollView2, mockedScrollView3, mockedScrollView4].forEach {
       $0.contentSize = size
-      scrollView.contentView.addSubview($0)
+      scrollView.documentView.addSubview($0)
     }
 
     scrollView.layoutViews()

--- a/FamilyTests/iOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/iOS/FamilyViewControllerTests.swift
@@ -51,11 +51,11 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(secondViewController.parent, familyViewController)
     XCTAssertEqual(thirdViewController.parent, familyViewController)
 
-    var wrapperView = (familyViewController.scrollView.contentView.subviews[0] as? FamilyWrapperView)
+    var wrapperView = (familyViewController.scrollView.documentView.subviews[0] as? FamilyWrapperView)
     XCTAssertEqual(wrapperView, firstViewController.view.superview)
-    wrapperView = (familyViewController.scrollView.contentView.subviews[1] as? FamilyWrapperView)
+    wrapperView = (familyViewController.scrollView.documentView.subviews[1] as? FamilyWrapperView)
     XCTAssertEqual(wrapperView, secondViewController.view.superview)
-    wrapperView = (familyViewController.scrollView.contentView.subviews[2] as? FamilyWrapperView)
+    wrapperView = (familyViewController.scrollView.documentView.subviews[2] as? FamilyWrapperView)
     XCTAssertEqual(wrapperView, thirdViewController.view.superview)
 
     XCTAssertEqual(familyViewController.scrollView.contentSize.height, 1500)
@@ -77,8 +77,8 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(mockedViewController1.parent, familyViewController)
     XCTAssertEqual(mockedViewController2.parent, familyViewController)
     XCTAssertEqual(familyViewController.children.count, 2)
-    XCTAssertEqual(familyViewController.scrollView.contentView, mockedViewController1.scrollView.superview)
-    XCTAssertEqual(familyViewController.scrollView.contentView, mockedViewController2.scrollView.superview)
+    XCTAssertEqual(familyViewController.scrollView.documentView, mockedViewController1.scrollView.superview)
+    XCTAssertEqual(familyViewController.scrollView.documentView, mockedViewController2.scrollView.superview)
 
     XCTAssertEqual(familyViewController.registry.count, 2)
     mockedViewController1.removeFromParent()

--- a/FamilyTests/macOS/FamilyContentViewTests.swift
+++ b/FamilyTests/macOS/FamilyContentViewTests.swift
@@ -18,11 +18,11 @@ class FamilyContentViewTests: XCTestCase {
   }
 
   var scrollView: FamilyScrollViewMock!
-  var contentView: FamilyContentView!
+  var contentView: FamilyDocumentView!
 
   override func setUp() {
     scrollView = FamilyScrollViewMock()
-    contentView = scrollView.documentView as? FamilyContentView
+    contentView = scrollView.documentView as? FamilyDocumentView
   }
 
   func testAddingRegularViewToContentView() {

--- a/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 protocol FamilyContentViewDelegate: class {
-  func familyContentView(_ view: FamilyContentView, didAddScrollView scrollView: UIScrollView)
+  func familyContentView(_ view: FamilyDocumentView, didAddScrollView scrollView: UIScrollView)
 }
 
 /// This classes acts as a view container for `FamilyScrollView`.
@@ -9,7 +9,7 @@ protocol FamilyContentViewDelegate: class {
 /// in `FamilyWrapperView`'s. This is done so that the `FamilyScrollView`
 /// only needs to take `UIScrollView` based views into account when performing
 /// its layout algorithm.
-public class FamilyContentView: UIView {
+public class FamilyDocumentView: UIView {
   weak var delegate: FamilyContentViewDelegate?
   weak var familyScrollView: FamilyScrollView?
 

--- a/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
-protocol FamilyContentViewDelegate: class {
-  func familyContentView(_ view: FamilyDocumentView, didAddScrollView scrollView: UIScrollView)
+protocol FamilyDocumentViewDelegate: class {
+  func familyDocumentView(_ view: FamilyDocumentView, didAddScrollView scrollView: UIScrollView)
 }
 
 /// This classes acts as a view container for `FamilyScrollView`.
@@ -10,7 +10,7 @@ protocol FamilyContentViewDelegate: class {
 /// only needs to take `UIScrollView` based views into account when performing
 /// its layout algorithm.
 public class FamilyDocumentView: UIView {
-  weak var delegate: FamilyContentViewDelegate?
+  weak var delegate: FamilyDocumentViewDelegate?
   weak var familyScrollView: FamilyScrollView?
 
   /// Convenience methods to return all subviews as scroll view.
@@ -34,7 +34,7 @@ public class FamilyDocumentView: UIView {
     default:
       let wrapper = FamilyWrapperView(frame: view.frame,
                                       view: view)
-      wrapper.parentContentView = self
+      wrapper.parentDocumentView = self
       subview = wrapper
     }
 
@@ -42,7 +42,7 @@ public class FamilyDocumentView: UIView {
 
     guard let scrollView = subview as? UIScrollView else { return }
 
-    delegate?.familyContentView(self, didAddScrollView: scrollView)
+    delegate?.familyDocumentView(self, didAddScrollView: scrollView)
   }
 
   /// Tells the view that a subview is about to be removed.

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -45,7 +45,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
 
   /// The content view is where all views get added when a view is used
   /// in the `Family` framework.
-  public var contentView: FamilyContentView = FamilyContentView()
+  public var contentView: FamilyDocumentView = FamilyDocumentView()
 
   deinit {
     subviewsInLayoutOrder.removeAll()
@@ -84,7 +84,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
     }
   }
 
-  func familyContentView(_ view: FamilyContentView,
+  func familyContentView(_ view: FamilyDocumentView,
                          didAddScrollView scrollView: UIScrollView) {
     didAddScrollViewToContainer(scrollView)
   }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestureRecognizerDelegate {
+public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestureRecognizerDelegate {
   /// The amount of spacing that should be inserted inbetween views.
   public var spacing: CGFloat {
     get { return spaceManager.spacing }
@@ -45,7 +45,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
 
   /// The content view is where all views get added when a view is used
   /// in the `Family` framework.
-  public var contentView: FamilyDocumentView = FamilyDocumentView()
+  public var documentView: FamilyDocumentView = FamilyDocumentView()
 
   deinit {
     subviewsInLayoutOrder.removeAll()
@@ -58,13 +58,13 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
   /// - Parameter frame: The frame rectangle for the view, measured in points.
   public required override init(frame: CGRect) {
     super.init(frame: frame)
-    contentView.delegate = self
-    contentView.familyScrollView = self
-    contentView.autoresizingMask = self.autoresizingMask
+    documentView.delegate = self
+    documentView.familyScrollView = self
+    documentView.autoresizingMask = self.autoresizingMask
     if #available(iOS 11.0, tvOS 11.0, *) {
       contentInsetAdjustmentBehavior = .never
     }
-    addSubview(contentView)
+    addSubview(documentView)
   }
 
   required public init?(coder aDecoder: NSCoder) {
@@ -84,7 +84,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
     }
   }
 
-  func familyContentView(_ view: FamilyDocumentView,
+  func familyDocumentView(_ view: FamilyDocumentView,
                          didAddScrollView scrollView: UIScrollView) {
     didAddScrollViewToContainer(scrollView)
   }
@@ -98,14 +98,14 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
   func didAddScrollViewToContainer(_ scrollView: UIScrollView) {
     scrollView.autoresizingMask = [.flexibleWidth]
 
-    guard contentView.subviews.index(of: scrollView) != nil else {
+    guard documentView.subviews.index(of: scrollView) != nil else {
       return
     }
 
     observeView(view: scrollView)
 
     subviewsInLayoutOrder.removeAll()
-    for scrollView in contentView.scrollViews {
+    for scrollView in documentView.scrollViews {
       subviewsInLayoutOrder.append(scrollView)
       configureScrollView(scrollView)
     }
@@ -129,7 +129,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
       }
     }
 
-    for scrollView in contentView.scrollViews {
+    for scrollView in documentView.scrollViews {
       configureScrollView(scrollView)
     }
 
@@ -169,7 +169,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
   ///
   /// - Parameter view: The view that should be observered.
   private func observeView(view: UIScrollView) {
-    guard view.superview == contentView else { return }
+    guard view.superview == documentView else { return }
 
     let contentSizeObserver = view.observe(\.contentSize, options: [.initial, .new, .old], changeHandler: { [weak self] (scrollView, value) in
       guard let strongSelf = self,
@@ -257,7 +257,7 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
 
   /// Remove wrapper views that don't own their underlaying views.
   func purgeWrapperViews() {
-    for case let wrapperView as FamilyWrapperView in contentView.subviews {
+    for case let wrapperView as FamilyWrapperView in documentView.subviews {
       if wrapperView != wrapperView.view.superview {
         wrapperView.removeFromSuperview()
       }
@@ -280,8 +280,8 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
   public func layoutViews(withDuration duration: CFTimeInterval? = nil) {
     guard superview != nil else { return }
 
-    contentView.frame = bounds
-    contentView.bounds = CGRect(origin: contentOffset, size: bounds.size)
+    documentView.frame = bounds
+    documentView.bounds = CGRect(origin: contentOffset, size: bounds.size)
 
     let animationDuration: TimeInterval? = subviewsInLayoutOrder
       .compactMap({ $0.layer.resolveAnimationDuration }).first ?? duration
@@ -325,9 +325,9 @@ public class FamilyScrollView: UIScrollView, FamilyContentViewDelegate, UIGestur
       frame.size.width = max(frame.size.width, self.frame.size.width)
 
       if scrollView is FamilyWrapperView {
-        newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
+        newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
       } else {
-        newHeight = fmin(contentView.frame.height, newHeight)
+        newHeight = fmin(documentView.frame.height, newHeight)
       }
 
       let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height ||

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -87,17 +87,17 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     switch childController {
     case let collectionViewController as UICollectionViewController:
       if let collectionView = collectionViewController.collectionView {
-        scrollView.contentView.addSubview(collectionView)
+        scrollView.documentView.addSubview(collectionView)
         childViewControllerView = collectionView
       } else {
         assertionFailure("Unable to resolve collection view from controller.")
         return
       }
     case let tableViewController as UITableViewController:
-      scrollView.contentView.addSubview(tableViewController.tableView)
+      scrollView.documentView.addSubview(tableViewController.tableView)
       childViewControllerView = tableViewController.tableView
     default:
-      scrollView.contentView.addSubview(childController.view)
+      scrollView.documentView.addSubview(childController.view)
       childViewControllerView = childController.view
     }
 
@@ -119,7 +119,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   open func addChild(_ childController: UIViewController, customSpacing: CGFloat? = nil, height: CGFloat) {
     childController.willMove(toParent: self)
     super.addChild(childController)
-    scrollView.contentView.addSubview(childController.view)
+    scrollView.documentView.addSubview(childController.view)
     childController.didMove(toParent: self)
     childController.view.translatesAutoresizingMaskIntoConstraints = true
     childController.view.frame.size.width = view.frame.size.width
@@ -184,7 +184,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       subview.frame.size.width = view.bounds.width
     }
 
-    scrollView.contentView.addSubview(subview)
+    scrollView.documentView.addSubview(subview)
     scrollView.frame = view.bounds
 
     if let spacing = spacing {

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -4,7 +4,7 @@ import UIKit
 /// from `UIScrollView`. This is done to ensure that the user gets a fluid and
 /// smooth scrolling experience when scrolling in a `FamilyScrollView`.
 class FamilyWrapperView: UIScrollView {
-  weak var parentContentView: FamilyContentView?
+  weak var parentContentView: FamilyDocumentView?
   /// The wrapped view
   var view: UIView
   /// Observers the frame of the wrapped view.

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -4,7 +4,7 @@ import UIKit
 /// from `UIScrollView`. This is done to ensure that the user gets a fluid and
 /// smooth scrolling experience when scrolling in a `FamilyScrollView`.
 class FamilyWrapperView: UIScrollView {
-  weak var parentContentView: FamilyDocumentView?
+  weak var parentDocumentView: FamilyDocumentView?
   /// The wrapped view
   var view: UIView
   /// Observers the frame of the wrapped view.
@@ -31,8 +31,8 @@ class FamilyWrapperView: UIScrollView {
     hiddenObserver = view.observe(\.isHidden, options: [.initial, .new, .old]) { [weak self] (_, value) in
       if value.newValue != value.oldValue, let newValue = value.newValue {
         self?.isHidden = newValue
-        self?.parentContentView?.familyScrollView?.setNeedsLayout()
-        self?.parentContentView?.familyScrollView?.layoutIfNeeded()
+        self?.parentDocumentView?.familyScrollView?.setNeedsLayout()
+        self?.parentDocumentView?.familyScrollView?.layoutIfNeeded()
       }
     }
 

--- a/Sources/macOS/Classes/FamilyClipView.swift
+++ b/Sources/macOS/Classes/FamilyClipView.swift
@@ -1,0 +1,14 @@
+import Cocoa
+
+class FamilyClipView: NSClipView {
+
+  override func scroll(to newOrigin: NSPoint) {
+    super.scroll(to: newOrigin)
+    guard let wrapperView = enclosingScrollView as? FamilyWrapperView,
+      let familyScrollView = wrapperView.enclosingScrollView as? FamilyScrollView else {
+        return
+    }
+
+    familyScrollView.scrollTo(newOrigin, in: documentView!)
+  }
+}

--- a/Sources/macOS/Classes/FamilyDocumentView.swift
+++ b/Sources/macOS/Classes/FamilyDocumentView.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-public class FamilyContentView: NSView {
+public class FamilyDocumentView: NSView {
   public override var isFlipped: Bool { return true }
 
   weak var familyScrollView: FamilyScrollView?

--- a/Sources/macOS/Classes/FamilyDocumentView.swift
+++ b/Sources/macOS/Classes/FamilyDocumentView.swift
@@ -18,7 +18,7 @@ public class FamilyDocumentView: NSView {
     default:
       let wrapper = FamilyWrapperView(frame: view.frame,
                                       wrappedView: view)
-      wrapper.parentContentView = self
+      wrapper.parentDocumentView = self
       subview = wrapper
     }
     super.addSubview(subview)

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -120,21 +120,23 @@ public class FamilyScrollView: NSScrollView {
 
   func scrollTo(_ point: CGPoint, in view: NSView) {
     guard !isScrollingByProxy,
+      !isScrolling,
+      !layoutIsRunning,
       view.window?.isVisible == true,
       let entry = cache.entry(for: view) else { return }
+
     var newOffset = CGPoint(x: self.contentOffset.x,
                             y: entry.origin.y + point.y)
-    let goingUp = newOffset.y < contentOffset.y
-    if goingUp {
-      newOffset.y -= contentView.contentInsets.top * 2
-    } else {
-      newOffset.y += contentView.contentInsets.top * 2
+
+    if newOffset.y < contentOffset.y {
+      newOffset.y -= contentView.contentInsets.top
     }
 
     isScrollingByProxy = true
     familyContentView.scroll(newOffset)
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+    let deadline: DispatchTime = DispatchTime.now() + NSAnimationContext.current.duration / 2
+    DispatchQueue.main.asyncAfter(deadline: deadline) {
       self.isScrollingByProxy = false
     }
   }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -2,7 +2,7 @@ import Cocoa
 
 public class FamilyScrollView: NSScrollView {
   public override var isFlipped: Bool { return true }
-  public lazy var familyContentView: FamilyContentView = .init()
+  public lazy var familyDocumentView: FamilyDocumentView = .init()
   public var spacing: CGFloat {
     get { return spaceManager.spacing }
     set {
@@ -19,13 +19,13 @@ public class FamilyScrollView: NSScrollView {
 
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
-    self.documentView = familyContentView
+    self.documentView = familyDocumentView
     self.drawsBackground = false
-    self.familyContentView.familyScrollView = self
+    self.familyDocumentView.familyScrollView = self
     configureObservers()
     hasVerticalScroller = true
     contentView.postsBoundsChangedNotifications = true
-    familyContentView.autoresizingMask = [.width]
+    familyDocumentView.autoresizingMask = [.width]
   }
 
   required public init?(coder: NSCoder) {
@@ -34,7 +34,7 @@ public class FamilyScrollView: NSScrollView {
 
   deinit {
     NotificationCenter.default.removeObserver(self)
-    familyContentView.subviews.forEach { $0.removeFromSuperview() }
+    familyDocumentView.subviews.forEach { $0.removeFromSuperview() }
     subviewsInLayoutOrder.forEach { $0.removeFromSuperview() }
     subviewsInLayoutOrder.removeAll()
   }
@@ -161,11 +161,11 @@ public class FamilyScrollView: NSScrollView {
   }
 
   func didAddScrollViewToContainer(_ scrollView: NSScrollView) {
-    if familyContentView.scrollViews.index(of: scrollView) != nil {
+    if familyDocumentView.scrollViews.index(of: scrollView) != nil {
       rebuildSubviewsInLayoutOrder()
       subviewsInLayoutOrder.removeAll()
 
-      for scrollView in familyContentView.scrollViews {
+      for scrollView in familyDocumentView.scrollViews {
         subviewsInLayoutOrder.append(scrollView)
       }
     }
@@ -204,7 +204,7 @@ public class FamilyScrollView: NSScrollView {
 
   private func rebuildSubviewsInLayoutOrder(exceptSubview: View? = nil) {
     subviewsInLayoutOrder.removeAll()
-    let filteredSubviews = familyContentView.scrollViews.filter({ !($0 === exceptSubview) })
+    let filteredSubviews = familyDocumentView.scrollViews.filter({ !($0 === exceptSubview) })
     subviewsInLayoutOrder = filteredSubviews
   }
 

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -91,7 +91,24 @@ public class FamilyScrollView: NSScrollView {
       name: NSWindow.didEndLiveResizeNotification,
       object: nil
     )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(didLiveScroll),
+      name: NSScrollView.didLiveScrollNotification,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(didEndLiveScroll),
+      name: NSScrollView.didEndLiveScrollNotification,
+      object: nil
+    )
   }
+
+  @objc func didLiveScroll() { isScrolling = true }
+  @objc func didEndLiveScroll() { isScrolling = false }
 
   @objc func contentViewBoundsDidChange(_ notification: NSNotification) {
     if (notification.object as? NSClipView) === contentView,

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -119,26 +119,21 @@ public class FamilyScrollView: NSScrollView {
   }
 
   func scrollTo(_ point: CGPoint, in view: NSView) {
-    guard !isScrollingByProxy,
+    guard isScrollingByProxy,
       !isScrolling,
       !layoutIsRunning,
       view.window?.isVisible == true,
       let entry = cache.entry(for: view) else { return }
-
     var newOffset = CGPoint(x: self.contentOffset.x,
                             y: entry.origin.y + point.y)
-
     if newOffset.y < contentOffset.y {
       newOffset.y -= contentView.contentInsets.top
     }
 
-    isScrollingByProxy = true
-    familyContentView.scroll(newOffset)
-
-    let deadline: DispatchTime = DispatchTime.now() + NSAnimationContext.current.duration / 2
-    DispatchQueue.main.asyncAfter(deadline: deadline) {
-      self.isScrollingByProxy = false
-    }
+    contentView.scroll(newOffset)
+    // This is invoked to avoid animation stutter.
+    contentView.scroll(to: newOffset)
+    isScrollingByProxy = false
   }
 
   // MARK: - Window resizing

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -54,7 +54,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   open override func addChild(_ childController: ViewController) {
     super.addChild(childController)
     childController.view.frame.size.width = view.bounds.width
-    scrollView.familyContentView.addSubview(childController.view)
+    scrollView.familyDocumentView.addSubview(childController.view)
     scrollView.frame = view.bounds
     registry[childController] = childController.view
   }
@@ -98,7 +98,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     } else {
       subview.frame.size.width = view.bounds.width
     }
-    scrollView.familyContentView.addSubview(subview)
+    scrollView.familyDocumentView.addSubview(subview)
     scrollView.frame = view.bounds
 
     if let spacing = spacing {

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -7,10 +7,13 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   public var constraints = [NSLayoutConstraint]()
   var registry = [ViewController: View]()
   var observer: NSKeyValueObservation?
+  var eventHandlerKeyDown: Any?
 
   deinit {
     children.forEach { $0.removeFromParent() }
     purgeRemovedViews()
+
+    if let eventHandlerKeyDown = eventHandlerKeyDown { NSEvent.removeMonitor(eventHandlerKeyDown) }
   }
 
   open override func loadView() {
@@ -28,6 +31,10 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     view.addSubview(scrollView)
     scrollView.autoresizingMask = [.width]
     configureConstraints()
+    eventHandlerKeyDown = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { (event) -> NSEvent? in
+      self.scrollView.isScrollingByProxy = true
+      return event
+    }
   }
 
   private func configureConstraints() {

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -1,6 +1,7 @@
 import Cocoa
 
 open class FamilyViewController: NSViewController, FamilyFriendly {
+  public lazy var baseView = NSView()
   public lazy var scrollView: FamilyScrollView = .init()
   /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
@@ -13,11 +14,10 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   }
 
   open override func loadView() {
-    let view = NSView()
+    let view = baseView
     view.autoresizingMask = [.width]
     view.autoresizesSubviews = true
     self.view = view
-
     observer = observe(\.children, options: [.new, .old], changeHandler: { controller, _ in
       controller.purgeRemovedViews()
     })
@@ -33,6 +33,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
     if #available(OSX 10.11, *) {
+      NSLayoutConstraint.deactivate(constraints)
       constraints.append(contentsOf: [
         scrollView.topAnchor.constraint(equalTo: view.topAnchor),
         scrollView.leftAnchor.constraint(equalTo: view.leftAnchor),

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -3,12 +3,15 @@ import Cocoa
 class FamilyClipView: NSClipView {
   override func scroll(to newOrigin: NSPoint) {
     super.scroll(to: newOrigin)
+
     guard
       let wrapperView = enclosingScrollView as? FamilyWrapperView,
       let familyScrollView = wrapperView.enclosingScrollView as? FamilyScrollView,
       !familyScrollView.isScrolling,
       let window = window,
-      !window.inLiveResize else { return }
+      !window.inLiveResize else {
+        return
+    }
 
     familyScrollView.scrollTo(newOrigin, in: documentView!)
   }

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -1,22 +1,5 @@
 import Cocoa
 
-class FamilyClipView: NSClipView {
-  override func scroll(to newOrigin: NSPoint) {
-    super.scroll(to: newOrigin)
-
-    guard
-      let wrapperView = enclosingScrollView as? FamilyWrapperView,
-      let familyScrollView = wrapperView.enclosingScrollView as? FamilyScrollView,
-      !familyScrollView.isScrolling,
-      let window = window,
-      !window.inLiveResize else {
-        return
-    }
-
-    familyScrollView.scrollTo(newOrigin, in: documentView!)
-  }
-}
-
 class FamilyWrapperView: NSScrollView {
   weak var parentContentView: FamilyContentView?
   var isScrolling: Bool = false
@@ -64,15 +47,6 @@ class FamilyWrapperView: NSScrollView {
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  @objc func contentViewBoundsDidChange(_ notification: NSNotification) {
-    guard let familyScrollView = parentContentView?.familyScrollView,
-      let window = window,
-      (notification.object as? NSClipView) === contentView,
-      !window.inLiveResize else { return }
-
-    familyScrollView.scrollTo(contentOffset, in: view)
   }
 
   override func scrollWheel(with event: NSEvent) {

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -1,7 +1,7 @@
 import Cocoa
 
 class FamilyWrapperView: NSScrollView {
-  weak var parentContentView: FamilyContentView?
+  weak var parentContentView: FamilyDocumentView?
   var isScrolling: Bool = false
   var view: NSView
   private lazy var clipView = FamilyClipView()

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -1,7 +1,7 @@
 import Cocoa
 
 class FamilyWrapperView: NSScrollView {
-  weak var parentContentView: FamilyDocumentView?
+  weak var parentDocumentView: FamilyDocumentView?
   var isScrolling: Bool = false
   var view: NSView
   private lazy var clipView = FamilyClipView()
@@ -67,7 +67,7 @@ class FamilyWrapperView: NSScrollView {
     }
 
     guard window?.inLiveResize != true, !isScrolling,
-      let familyScrollView = parentContentView?.familyScrollView else {
+      let familyScrollView = parentDocumentView?.familyScrollView else {
         return
     }
 


### PR DESCRIPTION
- Improves scrolling with keyboard events on macOS
- Renames `FamilyContentView` to `FamilyDocumentView` to avoid any confusion with `contentView` on `NSScrollView`.