### PR TITLE
Add caching to iOS and tvOS, refactor space manager to use insets and make constraints configurable.

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.7.3"
+  s.version          = "0.8.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -44,6 +44,10 @@
 		BD7629BE20349CA300C917BB /* FamilyFriendly.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7629BD20349CA300C917BB /* FamilyFriendly.swift */; };
 		BD7629BF20349CA300C917BB /* FamilyFriendly.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7629BD20349CA300C917BB /* FamilyFriendly.swift */; };
 		BD7629C020349CA300C917BB /* FamilyFriendly.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7629BD20349CA300C917BB /* FamilyFriendly.swift */; };
+		BDAC586E21B9916E00412766 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
+		BDAC586F21B9916E00412766 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
+		BDAC587021B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
+		BDAC587121B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
 		BDEE36352043394E00120E35 /* FamilyWrapperViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE36342043394E00120E35 /* FamilyWrapperViewTests.swift */; };
 		BDEE3637204369F200120E35 /* FamilyContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE3636204369F200120E35 /* FamilyContentViewTests.swift */; };
 		BDEE363920436B1100120E35 /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE363820436B1100120E35 /* FamilyScrollViewTests.swift */; };
@@ -187,6 +191,8 @@
 		BD2236DD2034A81500C465E4 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BD02F56621B43E5E006ECE48 /* FamilyCache.swift */,
+				BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */,
 				BD7629B920349C2500C917BB /* TypeAlias.swift */,
 				BD7629BD20349CA300C917BB /* FamilyFriendly.swift */,
 				BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */,
@@ -197,8 +203,6 @@
 		BD2236E02034B10F00C465E4 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				BD02F56621B43E5E006ECE48 /* FamilyCache.swift */,
-				BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */,
 				BD4C7FE320349B030037D3E5 /* FamilyDocumentView.swift */,
 				BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */,
 				BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */,
@@ -644,10 +648,12 @@
 				BD5A80412030A9D9006A5EBB /* FamilyWrapperView.swift in Sources */,
 				BD5A80432030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
 				BD5A803F2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
+				BDAC586F21B9916E00412766 /* FamilyCache.swift in Sources */,
 				BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */,
 				BD5A803D2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80452030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629C020349CA300C917BB /* FamilyFriendly.swift in Sources */,
+				BDAC587121B9916E00412766 /* FamilyCacheEntry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -678,10 +684,12 @@
 				BD5A80402030A9D9006A5EBB /* FamilyWrapperView.swift in Sources */,
 				BD5A80422030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
 				BD5A803E2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
+				BDAC586E21B9916E00412766 /* FamilyCache.swift in Sources */,
 				BD535E162079269200AA2EC4 /* FamilySpaceManager.swift in Sources */,
 				BD5A803C2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80442030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629BE20349CA300C917BB /* FamilyFriendly.swift in Sources */,
+				BDAC587021B9916E00412766 /* FamilyCacheEntry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FamilyTests/iOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/iOS/FamilyScrollViewTests.swift
@@ -98,20 +98,20 @@ class FamilyScrollViewTests: XCTestCase {
 
     // Check that layout algorithm takes spacing between views into account.
 
-    scrollView.spacing = 10
+    scrollView.insets = .init(top: 0, left: 0, bottom: 10, right: 0)
     scrollView.layoutSubviews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: .zero, size: size))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + scrollView.spacing), size: size))
-    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + scrollView.spacing * 2), size: size))
-    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + scrollView.spacing * 3),
-                                                   size: CGSize(width: size.width, height: size.height - scrollView.spacing * 3)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + scrollView.insets.bottom), size: size))
+    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + scrollView.insets.bottom * 2), size: size))
+    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + scrollView.insets.bottom * 3),
+                                                   size: CGSize(width: size.width, height: size.height - scrollView.insets.bottom * 3)))
 
     XCTAssertEqual(scrollView.contentSize.height, 1040)
 
-    scrollView.spacing = 0
-    scrollView.setCustomSpacing(10, after: mockedScrollView1)
-    scrollView.setCustomSpacing(10, after: mockedScrollView3)
+    scrollView.insets = .zero
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 10, right: 0), for: mockedScrollView1)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 10, right: 0), for: mockedScrollView3)
     scrollView.layoutSubviews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: .zero, size: size))
@@ -121,8 +121,8 @@ class FamilyScrollViewTests: XCTestCase {
                                                    size: CGSize(width: size.width, height: size.height - 20)))
     XCTAssertEqual(scrollView.contentSize.height, 1020)
 
-    scrollView.setCustomSpacing(0, after: mockedScrollView1)
-    scrollView.setCustomSpacing(0, after: mockedScrollView3)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 0, right: 0), for: mockedScrollView1)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 0, right: 0), for: mockedScrollView3)
 
     scrollView.setContentOffset(CGPoint(x: 0, y: 250), animated: false)
     scrollView.layoutSubviews()
@@ -136,7 +136,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 500), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
@@ -144,8 +144,8 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 750), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
   }

--- a/FamilyTests/macOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/macOS/FamilyScrollViewTests.swift
@@ -48,43 +48,44 @@ class FamilyScrollViewTests: XCTestCase {
 
     // Check that layout algorithm takes spacing between views into account.
 
-    scrollView.spacing = 10
+    scrollView.insets = .init(top: 0, left: 0, bottom: 10, right: 0)
     scrollView.layoutViews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: .zero, size: size))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + scrollView.spacing), size: size))
-    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + scrollView.spacing * 2), size: size))
-    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + scrollView.spacing * 3),
-                                                   size: CGSize(width: size.width, height: size.height - scrollView.spacing * 3)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + scrollView.insets.bottom), size: size))
+    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + scrollView.insets.bottom * 2), size: size))
+    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + scrollView.insets.bottom * 3),
+                                                   size: CGSize(width: size.width, height: size.height - scrollView.insets.bottom * 3)))
     scrollView.layout()
     XCTAssertEqual(scrollView.documentView?.frame.size.height, 1040)
 
-    scrollView.spacing = 0
+    scrollView.insets = .init(top: 0, left: 0, bottom: 0, right: 0)
 
-    scrollView.setCustomSpacing(10, after: mockedScrollView1)
-    scrollView.setCustomSpacing(10, after: mockedScrollView3)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 10, right: 0), for: mockedScrollView1)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 10, right: 0), for: mockedScrollView3)
     scrollView.layoutViews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: .zero, size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + 10), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + 10), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + 20),
-                                                   size: CGSize(width: size.width, height: size.height - 20)))
-    scrollView.layout()
-    XCTAssertEqual(scrollView.documentView?.frame.size.height, 1020)
+                                                   size: CGSize(width: size.width, height: size.height - 30)))
+    XCTAssertEqual(scrollView.documentView?.frame.size.height, 1000)
 
-    scrollView.setCustomSpacing(0, after: mockedScrollView1)
-    scrollView.setCustomSpacing(0, after: mockedScrollView3)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 0, right: 0), for: mockedScrollView1)
+    scrollView.setCustomInsets(.init(top: 0, left: 0, bottom: 0, right: 0), for: mockedScrollView3)
     scrollView.layoutViews()
 
     scrollView.contentOffset.y = 250
     scrollView.layoutViews()
     scrollView.layout()
 
+    let lastSize = CGSize(width: 500, height: 220)
+
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
-    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
+    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: lastSize))
     XCTAssertEqual(scrollView.documentView?.frame.size.height, 1000)
 
     scrollView.contentOffset.y = 500
@@ -94,7 +95,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
-    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
+    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: lastSize))
 
     scrollView.contentOffset.y = 750
     scrollView.layoutViews()
@@ -102,7 +103,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
-    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
+    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: lastSize))
 
     let rect = CGRect(origin: .zero, size: CGSize(width: 500, height: 1250))
     let window = NSWindow()
@@ -112,7 +113,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
-    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
+    XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: lastSize))
 
     scrollView = nil
   }

--- a/Sources/Shared/FamilyCache.swift
+++ b/Sources/Shared/FamilyCache.swift
@@ -1,8 +1,8 @@
-import Cocoa
+import CoreGraphics
 
 class FamilyCache: NSObject {
   var contentSize: CGSize = .zero
-  var storage = [NSView: FamilyCacheEntry]()
+  var storage = [View: FamilyCacheEntry]()
   var isEmpty: Bool { return storage.isEmpty }
   override init() {}
 
@@ -10,7 +10,7 @@ class FamilyCache: NSObject {
     storage[entry.view] = entry
   }
 
-  func entry(for view: NSView) -> FamilyCacheEntry? {
+  func entry(for view: View) -> FamilyCacheEntry? {
     return storage[view]
   }
 

--- a/Sources/Shared/FamilyCacheEntry.swift
+++ b/Sources/Shared/FamilyCacheEntry.swift
@@ -1,13 +1,15 @@
-import Cocoa
+import CoreGraphics
 
 class FamilyCacheEntry: NSObject {
-  var view: NSView
+  var view: View
   var origin: CGPoint
   var contentSize: CGSize
+  var maxY: CGFloat
 
-  init(view: NSView, origin: CGPoint, contentSize: CGSize) {
+  init(view: View, origin: CGPoint, contentSize: CGSize) {
     self.view = view
     self.origin = origin
     self.contentSize = contentSize
+    self.maxY = contentSize.height + origin.y
   }
 }

--- a/Sources/Shared/FamilyFriendly.swift
+++ b/Sources/Shared/FamilyFriendly.swift
@@ -3,8 +3,8 @@ import Foundation
 
 protocol FamilyFriendly: class {
   func addChild(_ childController: ViewController)
-  func addChild(_ childController: ViewController, customSpacing: CGFloat?, height: CGFloat)
-  func addChild<T: ViewController>(_ childController: T, customSpacing: CGFloat?, view closure: (T) -> View)
+  func addChild(_ childController: ViewController, customInsets: Insets?, height: CGFloat)
+  func addChild<T: ViewController>(_ childController: T, customInsets: Insets?, view closure: (T) -> View)
   func addChildren(_ childControllers: ViewController ...)
 
   func purgeRemovedViews()

--- a/Sources/Shared/FamilySpaceManager.swift
+++ b/Sources/Shared/FamilySpaceManager.swift
@@ -1,36 +1,32 @@
 import CoreGraphics
 
 class FamilySpaceManager {
-  /// A dictionary of the views and what custom spacing they should use.
-  private var registry = [View: CGFloat]()
-  /// The spacing used between views.
-  var spacing: CGFloat = 0
+  /// A dictionary of the views and what custom insets they should use.
+  private var registry = [View: Insets]()
+  /// The isnets used between views.
+  var insets: Insets = .init(top: 0, left: 0, bottom: 0, right: 0)
 
-  /// Get custom spacing for the view, if the view does not have custom spacing
+  /// Get custom insets for the view, if the view does not have custom insets
   /// then the general spacing will be returned.
   ///
   /// - Parameter view: The view that should be used to resolve the value.
-  /// - Returns: The amount of spacing that should appear after the view, either
-  ///            custom spacing or the general spacing.
-  func customSpacing(after view: View) -> CGFloat {
+  /// - Returns: The amount of insets that should appear after the view, either
+  ///            custom insets or the general insets.
+  func customInsets(for view: View) -> Insets {
     if let value = registry[view] {
       return value
     } else {
-      return spacing
+      return insets
     }
   }
 
-  func negativeSpace() -> CGFloat {
-    return registry.filter({ $0.value < 0 }).compactMap({ $0.value }).reduce(0, { $0 + $1 })
-  }
-
-  /// Set custom spacing after view.
+  /// Set custom insets for view.
   ///
   /// - Parameters:
-  ///   - spacing: The spacing that should be added after the view.
-  ///   - view: The view that should get custom spacing after the view.
-  func setCustomSpacing(_ spacing: CGFloat, after view: View) {
-    registry[view] = spacing
+  ///   - insets: The insets that should be added after the view.
+  ///   - view: The view that should get custom insets for the view.
+  func setCustomInsets(_ insets: Insets, for view: View) {
+    registry[view] = insets
   }
 
   /// Remove view from registry.

--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -2,8 +2,10 @@
   import Cocoa
   public typealias ViewController = NSViewController
   public typealias View = NSView
+  public typealias Insets = NSEdgeInsets
 #else
   import UIKit
   public typealias ViewController = UIViewController
   public typealias View = UIView
+  public typealias Insets = UIEdgeInsets
 #endif

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -4,7 +4,10 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   /// The amount of spacing that should be inserted inbetween views.
   public var spacing: CGFloat {
     get { return spaceManager.spacing }
-    set { spaceManager.spacing = newValue }
+    set {
+      spaceManager.spacing = newValue
+      cache.clear()
+    }
   }
   /// A collection of scroll views that is used to order the views on screen.
   /// This collection is used by the layout algorithm that render the views and
@@ -28,6 +31,8 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   private var observers = [Observer]()
 
   private lazy var spaceManager = FamilySpaceManager()
+
+  lazy var cache = FamilyCache()
 
   private var isScrolling: Bool { return isTracking || isDragging || isDecelerating }
 
@@ -96,6 +101,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   /// - Parameter scrollView: The scroll view that should be configured
   ///                         and observed.
   func didAddScrollViewToContainer(_ scrollView: UIScrollView) {
+    defer { cache.clear() }
     scrollView.autoresizingMask = [.flexibleWidth]
 
     guard documentView.subviews.index(of: scrollView) != nil else {
@@ -119,6 +125,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   ///
   /// - Parameter subview: The subview that got removed from the view heirarcy.
   open override func willRemoveSubview(_ subview: UIView) {
+    defer { cache.clear() }
     if let index = subviewsInLayoutOrder.index(where: { $0 == subview }) {
       subviewsInLayoutOrder.remove(at: index)
     }
@@ -179,7 +186,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       }
 
       if self?.compare(newValue, to: oldValue) == false {
-        strongSelf.computeContentSize()
+        strongSelf.cache.clear()
         strongSelf.layoutViews()
       }
     })
@@ -244,7 +251,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   open override func layoutSubviews() {
     super.layoutSubviews()
     layoutViews()
-    computeContentSize()
   }
 
   public func customSpacing(after view: View) -> CGFloat {
@@ -253,6 +259,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
   public func setCustomSpacing(_ spacing: CGFloat, after view: View) {
     spaceManager.setCustomSpacing(spacing, after: view)
+    cache.clear()
   }
 
   /// Remove wrapper views that don't own their underlaying views.
@@ -301,58 +308,106 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   /// when a view changes size or origin. It also scales the frame of scroll views
   /// in order to keep dequeuing for table and collection views.
   private func runLayoutSubviewsAlgorithm() {
-    var yOffsetOfCurrentSubview: CGFloat = 0.0
-    for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
-      if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
-        continue
+    if cache.isEmpty {
+      var yOffsetOfCurrentSubview: CGFloat = 0.0
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+          continue
+        }
+
+        var frame = scrollView.frame
+        var contentOffset = scrollView.contentOffset
+
+        if self.contentOffset.y < yOffsetOfCurrentSubview {
+          contentOffset.y = 0.0
+          frame.origin.y = floor(yOffsetOfCurrentSubview)
+        } else {
+          contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
+          frame.origin.y = floor(self.contentOffset.y)
+        }
+
+        let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
+        let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+
+        frame.size.width = max(frame.size.width, self.frame.size.width)
+
+        if scrollView is FamilyWrapperView {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        } else {
+          newHeight = fmin(documentView.frame.height, newHeight)
+        }
+
+        let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height ||
+          self.contentOffset.y != frame.minY
+
+        if shouldModifyContentOffset {
+          if !compare(scrollView.contentOffset, to: contentOffset) {
+            scrollView.contentOffset.y = contentOffset.y
+          }
+        } else {
+          frame.origin.y = yOffsetOfCurrentSubview
+        }
+
+        frame.size.height = newHeight
+
+        if frame.size.width != self.frame.width {
+          frame.size.width = self.frame.width
+        }
+
+        if scrollView.frame != frame {
+          scrollView.frame = frame
+        }
+
+        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + spaceManager.customSpacing(after: view)
+        cache.add(entry: FamilyCacheEntry(view: view,
+                                          origin: frame.origin,
+                                          contentSize: scrollView.contentSize))
       }
+      computeContentSize()
+    } else {
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+        guard let entry = cache.entry(for: view) else { continue }
+        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+          continue
+        }
 
-      var frame = scrollView.frame
-      var contentOffset = scrollView.contentOffset
+        var frame = scrollView.frame
+        var contentOffset = scrollView.contentOffset
 
-      if self.contentOffset.y < yOffsetOfCurrentSubview {
-        contentOffset.y = 0.0
-        frame.origin.y = floor(yOffsetOfCurrentSubview)
-      } else {
-        contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
-        frame.origin.y = floor(self.contentOffset.y)
-      }
+        if self.contentOffset.y < entry.origin.y {
+          contentOffset.y = 0.0
+          frame.origin.y = floor(entry.origin.y)
+        } else {
+          contentOffset.y = self.contentOffset.y - entry.origin.y
+          frame.origin.y = floor(self.contentOffset.y)
+        }
 
-      let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
-      let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
-      var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+        let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)
+        let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
 
-      frame.size.width = max(frame.size.width, self.frame.size.width)
+        if scrollView is FamilyWrapperView {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        } else {
+          newHeight = fmin(documentView.frame.height, newHeight)
+        }
 
-      if scrollView is FamilyWrapperView {
-        newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
-      } else {
-        newHeight = fmin(documentView.frame.height, newHeight)
-      }
+        let shouldScroll = self.contentOffset.y >= entry.origin.y && self.contentOffset.y <= entry.maxY
 
-      let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height ||
-        self.contentOffset.y != frame.minY
-
-      if shouldModifyContentOffset {
-        if !compare(scrollView.contentOffset, to: contentOffset) {
+        if shouldScroll {
           scrollView.contentOffset.y = contentOffset.y
         }
-      } else {
-        frame.origin.y = yOffsetOfCurrentSubview
-      }
 
-      frame.size.height = newHeight
-
-      if frame.size.width != self.frame.width {
+        frame.size.height = newHeight
         frame.size.width = self.frame.width
-      }
 
-      if scrollView.frame != frame {
-        scrollView.frame = frame
+        if scrollView.frame != frame {
+          scrollView.frame = frame
+        }
       }
-
-      let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
-      yOffsetOfCurrentSubview += scrollView.contentSize.height + spaceManager.customSpacing(after: view)
     }
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -15,7 +15,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
 
-  public var safeAreaLayoutConstraints: Bool = false {
+  public var safeAreaLayoutConstraints: Bool = true {
     didSet { configureConstraints() }
   }
 
@@ -54,6 +54,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
+  @objc func injected() {}
+
   /// Configure constraints for the scroll view.
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -61,12 +63,12 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     constraints.removeAll()
     if #available(iOS 11.0, tvOS 11.0, *) {
       let topAnchor = safeAreaLayoutConstraints
-        ? view.topAnchor
-        : view.safeAreaLayoutGuide.topAnchor
+        ? view.safeAreaLayoutGuide.topAnchor
+        : view.topAnchor
 
       let bottomAnchor = safeAreaLayoutConstraints
-        ? view.bottomAnchor
-        : view.safeAreaLayoutGuide.bottomAnchor
+        ? view.safeAreaLayoutGuide.bottomAnchor
+        : view.bottomAnchor
 
       constraints.append(contentsOf: [
         scrollView.topAnchor.constraint(equalTo: topAnchor),

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 /// adds the controllers view or custom view to view heirarcy inside the
 /// content view of the `FamilyScrollView`.
 open class FamilyViewController: UIViewController, FamilyFriendly {
-//  var observers = [NSKeyValueObservation]()
   var registry = [ViewController: (view: View, observer: NSKeyValueObservation)]()
 
   /// A custom implementation of a `UIScrollView` that handles continious scrolling
@@ -131,7 +130,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// - Parameters:
   ///   - childController: The view controller to be added as a child.
   ///   - height: The height that the child controllers should be constrained to.
-  open func addChild(_ childController: UIViewController, customSpacing: CGFloat? = nil, height: CGFloat) {
+  open func addChild(_ childController: UIViewController, customInsets: Insets? = nil, height: CGFloat) {
     childController.willMove(toParent: self)
     super.addChild(childController)
     scrollView.documentView.addSubview(childController.view)
@@ -142,8 +141,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     childController.view.frame.size.height = height
     registry[childController] = (childController.view, observe(childController))
 
-    if let customSpacing = customSpacing {
-      setCustomSpacing(customSpacing, after: childController.view)
+    if let customInsets = customInsets {
+      setCustomInsets(customInsets, for: childController.view)
     }
 
     scrollView.purgeWrapperViews()
@@ -157,7 +156,9 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   ///   - childController: The view controller to be added as a child.
   ///   - closure: A closure used to resolve a view other than `.view` on controller used
   ///              to render the view controller.
-  public func addChild<T: UIViewController>(_ childController: T, customSpacing spacing: CGFloat? = nil, view closure: (T) -> UIView) {
+  public func addChild<T: UIViewController>(_ childController: T,
+                                            customInsets insets: Insets? = nil,
+                                            view closure: (T) -> UIView) {
     childController.willMove(toParent: self)
     super.addChild(childController)
     view.addSubview(childController.view)
@@ -169,7 +170,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       (childView as? UIScrollView)?.contentInsetAdjustmentBehavior = .never
     }
 
-    addView(childView, customSpacing: spacing)
+    addView(childView, customInsets: insets)
     childController.didMove(toParent: self)
     registry[childController] = (childView, observe(childController))
     scrollView.purgeWrapperViews()
@@ -191,7 +192,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  public func addView(_ subview: View, withHeight height: CGFloat? = nil, customSpacing spacing: CGFloat? = nil) {
+  public func addView(_ subview: View, withHeight height: CGFloat? = nil, customInsets insets: Insets? = nil) {
     if let height = height {
       subview.frame.size.width = view.bounds.size.width
       subview.frame.size.height = height
@@ -202,17 +203,19 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     scrollView.documentView.addSubview(subview)
     scrollView.frame = view.bounds
 
-    if let spacing = spacing {
-      setCustomSpacing(spacing, after: subview)
+    if let insets = insets {
+      setCustomInsets(insets, for: subview)
     }
   }
 
-  public func customSpacing(after view: View) -> CGFloat {
-    return scrollView.customSpacing(after: view)
+  public func customInsets(for view: View) -> Insets {
+    return scrollView.customInsets(for: view)
   }
 
-  public func setCustomSpacing(_ spacing: CGFloat, after view: View) {
-    scrollView.setCustomSpacing(spacing, after: view)
+  public func setCustomInsets(_ insets: Insets, for view: View) {
+    view.frame.origin.x = insets.left
+    view.frame.size.width = self.view.frame.size.width - insets.left - insets.right
+    scrollView.setCustomInsets(insets, for: view)
   }
 
   /// Remove stray views from view hierarcy.

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -15,6 +15,10 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
 
+  public var safeAreaLayoutConstraints: Bool = false {
+    didSet { configureConstraints() }
+  }
+
   deinit {
     children.forEach {
       $0.willMove(toParent: nil)
@@ -53,10 +57,20 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// Configure constraints for the scroll view.
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.deactivate(constraints)
+    constraints.removeAll()
     if #available(iOS 11.0, tvOS 11.0, *) {
+      let topAnchor = safeAreaLayoutConstraints
+        ? view.topAnchor
+        : view.safeAreaLayoutGuide.topAnchor
+
+      let bottomAnchor = safeAreaLayoutConstraints
+        ? view.bottomAnchor
+        : view.safeAreaLayoutGuide.bottomAnchor
+
       constraints.append(contentsOf: [
-        scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-        scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        scrollView.topAnchor.constraint(equalTo: topAnchor),
+        scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
         scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
         scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
       ])
@@ -70,7 +84,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
         ])
       }
     }
-
     NSLayoutConstraint.activate(constraints)
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -53,8 +53,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  @objc func injected() {}
-
   /// Configure constraints for the scroll view.
   private func configureConstraints() {
     scrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -1,6 +1,7 @@
 import Cocoa
 
 open class FamilyViewController: NSViewController, FamilyFriendly {
+
   public lazy var baseView = NSView()
   public lazy var scrollView: FamilyScrollView = .init()
   /// The scroll view constraints.
@@ -60,7 +61,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     registry[childController] = childController.view
   }
 
-  public func addChild(_ childController: ViewController, customSpacing spacing: CGFloat? = nil, height: CGFloat) {
+  public func addChild(_ childController: ViewController, customInsets insets: Insets? = nil, height: CGFloat) {
     addChild(childController)
     childController.view.translatesAutoresizingMaskIntoConstraints = true
     childController.view.autoresizingMask = [.width]
@@ -68,17 +69,17 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     childController.view.frame.size.width = view.bounds.width
     scrollView.frame = view.bounds
 
-    if let spacing = spacing {
-      setCustomSpacing(spacing, after: childController.view)
+    if let insets = insets {
+      setCustomInsets(insets, for: childController.view)
     }
   }
 
-  public func addChild<T: ViewController>(_ childController: T, customSpacing spacing: CGFloat? = nil, view closure: (T) -> View) {
+  public func addChild<T: ViewController>(_ childController: T, customInsets insets: Insets? = nil, view closure: (T) -> View) {
     super.addChild(childController)
     view.addSubview(childController.view)
     childController.view.frame.size = .zero
     let childView = closure(childController)
-    addView(childView, customSpacing: spacing)
+    addView(childView, customInsets: insets)
     registry[childController] = childView
   }
 
@@ -92,7 +93,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     }
   }
 
-  public func addView(_ subview: View, customSpacing spacing: CGFloat? = nil, withHeight height: CGFloat? = nil) {
+  public func addView(_ subview: View, customInsets insets: Insets? = nil, withHeight height: CGFloat? = nil) {
     if let height = height {
       subview.frame.size.width = view.bounds.size.width
       subview.frame.size.height = height
@@ -102,17 +103,17 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     scrollView.familyDocumentView.addSubview(subview)
     scrollView.frame = view.bounds
 
-    if let spacing = spacing {
-      setCustomSpacing(spacing, after: view)
+    if let insets = insets {
+      setCustomInsets(insets, for: view)
     }
   }
 
-  public func customSpacing(after view: View) -> CGFloat {
-    return scrollView.customSpacing(after: view)
+  public func customInsets(for view: View) -> Insets {
+    return scrollView.customInsets(for: view)
   }
 
-  public func setCustomSpacing(_ spacing: CGFloat, after view: View) {
-    scrollView.setCustomSpacing(spacing, after: view)
+  public func setCustomInsets(_ insets: Insets, for view: View) {
+    scrollView.setCustomInsets(insets, for: view)
   }
 
   func purgeRemovedViews() {


### PR DESCRIPTION
This PR does a little bit more than I wanted it to do, the main points are:

- iOS and tvOS now share a similar layout algorithm optimization, namely size caching. Just like macOS, the origins, content size etc are now cached during the initial run and then a leaner implementation is used to handle scrolling events.

- The `SpaceManager` has been refactored in order to work with `insets` rather than just setting spacing below the view. That way you can add margins on `top`, `left`, `right` and `bottom` which makes it way more flexible.

- The scroll view constraints are now configurable on `FamilViewController` on iOS and tvOS. The controller now has a new property called `safeAreaLayoutConstraints`. This will determine if safe areas should be used or not. You can also change the layout constraints of the `FamilyScrollView` by deactivating `.constraints` and adding your own.