### PR TITLE
Optimize layout algorithm on tvOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.8.0"
+  s.version          = "0.8.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.8.1"
+  s.version          = "0.9.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		BD5A804C2030AC9F006A5EBB /* FamilyWrapperViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A804B2030AC9F006A5EBB /* FamilyWrapperViewTests.swift */; };
 		BD5A804D2030AC9F006A5EBB /* FamilyWrapperViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A804B2030AC9F006A5EBB /* FamilyWrapperViewTests.swift */; };
 		BD5A804F2030ACBA006A5EBB /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A804E2030ACBA006A5EBB /* FamilyScrollViewTests.swift */; };
-		BD5A80502030ACBA006A5EBB /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A804E2030ACBA006A5EBB /* FamilyScrollViewTests.swift */; };
 		BD5A80522030ACFE006A5EBB /* CALayerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80512030ACFD006A5EBB /* CALayerExtensionTests.swift */; };
 		BD5A80542030ACFE006A5EBB /* CALayerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A80512030ACFD006A5EBB /* CALayerExtensionTests.swift */; };
 		BD7055E72043FB9600C2C5CB /* FamilyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7055E62043FB9600C2C5CB /* FamilyViewControllerTests.swift */; };
@@ -48,6 +47,9 @@
 		BDAC586F21B9916E00412766 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
 		BDAC587021B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
 		BDAC587121B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
+		BDAC588321BA613A00412766 /* FamilyScrollView+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588221BA613A00412766 /* FamilyScrollView+tvOS.swift */; };
+		BDAC588521BA61CA00412766 /* FamilScrollView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588421BA61CA00412766 /* FamilScrollView+iOS.swift */; };
+		BDAC588921BA63B800412766 /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588821BA63B800412766 /* FamilyScrollViewTests.swift */; };
 		BDEE36352043394E00120E35 /* FamilyWrapperViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE36342043394E00120E35 /* FamilyWrapperViewTests.swift */; };
 		BDEE3637204369F200120E35 /* FamilyContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE3636204369F200120E35 /* FamilyContentViewTests.swift */; };
 		BDEE363920436B1100120E35 /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE363820436B1100120E35 /* FamilyScrollViewTests.swift */; };
@@ -109,6 +111,9 @@
 		BD7055E82044007300C2C5CB /* NSScrollViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSScrollViewExtensionsTests.swift; sourceTree = "<group>"; };
 		BD7629B920349C2500C917BB /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BD7629BD20349CA300C917BB /* FamilyFriendly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyFriendly.swift; sourceTree = "<group>"; };
+		BDAC588221BA613A00412766 /* FamilyScrollView+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FamilyScrollView+tvOS.swift"; sourceTree = "<group>"; };
+		BDAC588421BA61CA00412766 /* FamilScrollView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FamilScrollView+iOS.swift"; sourceTree = "<group>"; };
+		BDAC588821BA63B800412766 /* FamilyScrollViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyScrollViewTests.swift; sourceTree = "<group>"; };
 		BDEE36342043394E00120E35 /* FamilyWrapperViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyWrapperViewTests.swift; sourceTree = "<group>"; };
 		BDEE3636204369F200120E35 /* FamilyContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyContentViewTests.swift; sourceTree = "<group>"; };
 		BDEE363820436B1100120E35 /* FamilyScrollViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyScrollViewTests.swift; sourceTree = "<group>"; };
@@ -257,6 +262,22 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		BDAC588021BA611100412766 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BDAC588421BA61CA00412766 /* FamilScrollView+iOS.swift */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		BDAC588121BA611100412766 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				BDAC588221BA613A00412766 /* FamilyScrollView+tvOS.swift */,
+			);
+			path = tvOS;
+			sourceTree = "<group>";
+		};
 		D284B12D1F7906DA00D94AF3 /* macOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -280,6 +301,7 @@
 		D284B1341F7906DA00D94AF3 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				BDAC588821BA63B800412766 /* FamilyScrollViewTests.swift */,
 				D284B13D1F7907AD00D94AF3 /* tvOSTests.swift */,
 			);
 			path = tvOS;
@@ -337,6 +359,8 @@
 		D5C629691C3A809D007F7B7C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				BDAC588021BA611100412766 /* iOS */,
+				BDAC588121BA611100412766 /* tvOS */,
 				BD2236DD2034A81500C465E4 /* Shared */,
 				BD4C7FDE20349A950037D3E5 /* macOS */,
 				BD5A80342030A9D9006A5EBB /* iOS+tvOS */,
@@ -650,6 +674,7 @@
 				BD5A803F2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
 				BDAC586F21B9916E00412766 /* FamilyCache.swift in Sources */,
 				BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */,
+				BDAC588321BA613A00412766 /* FamilyScrollView+tvOS.swift in Sources */,
 				BD5A803D2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80452030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629C020349CA300C917BB /* FamilyFriendly.swift in Sources */,
@@ -663,8 +688,8 @@
 			files = (
 				BD5A804D2030AC9F006A5EBB /* FamilyWrapperViewTests.swift in Sources */,
 				BD5A804A2030AC84006A5EBB /* FamilyViewControllerTests.swift in Sources */,
-				BD5A80502030ACBA006A5EBB /* FamilyScrollViewTests.swift in Sources */,
 				D284B13E1F7907AD00D94AF3 /* tvOSTests.swift in Sources */,
+				BDAC588921BA63B800412766 /* FamilyScrollViewTests.swift in Sources */,
 				BD5A80542030ACFE006A5EBB /* CALayerExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -685,6 +710,7 @@
 				BD5A80422030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
 				BD5A803E2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
 				BDAC586E21B9916E00412766 /* FamilyCache.swift in Sources */,
+				BDAC588521BA61CA00412766 /* FamilScrollView+iOS.swift in Sources */,
 				BD535E162079269200AA2EC4 /* FamilySpaceManager.swift in Sources */,
 				BD5A803C2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80442030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,

--- a/FamilyTests/iOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/iOS/FamilyScrollViewTests.swift
@@ -127,7 +127,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 250), animated: false)
     scrollView.layoutSubviews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
@@ -136,17 +136,17 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 500), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
 
     scrollView.setContentOffset(CGPoint(x: 0, y: 750), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
   }
 }

--- a/FamilyTests/tvOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/tvOS/FamilyScrollViewTests.swift
@@ -126,7 +126,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 250), animated: false)
     scrollView.layoutSubviews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
@@ -135,17 +135,17 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 500), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
 
     scrollView.setContentOffset(CGPoint(x: 0, y: 750), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
   }
 }

--- a/FamilyTests/tvOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/tvOS/FamilyScrollViewTests.swift
@@ -126,7 +126,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 250), animated: false)
     scrollView.layoutSubviews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
@@ -135,17 +135,17 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 500), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
 
     scrollView.setContentOffset(CGPoint(x: 0, y: 750), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Code Coverage](https://codecov.io/github/zenangst/Family/coverage.svg?branch=master)
 [![License](https://img.shields.io/cocoapods/l/Family.svg?style=flat)](http://cocoadocs.org/docsets/Family)
 [![Platform](https://img.shields.io/cocoapods/p/Family.svg?style=flat)](http://cocoadocs.org/docsets/Family)
-![Swift](https://img.shields.io/badge/%20in-swift%204.0-orange.svg)
+![Swift](https://img.shields.io/badge/%20in-swift%204.2-orange.svg)
 
 </div>
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -125,7 +125,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   ///
   /// - Parameter subview: The subview that got removed from the view heirarcy.
   open override func willRemoveSubview(_ subview: UIView) {
-    defer { cache.clear() }
     if let index = subviewsInLayoutOrder.index(where: { $0 == subview }) {
       subviewsInLayoutOrder.remove(at: index)
     }
@@ -140,6 +139,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       configureScrollView(scrollView)
     }
 
+    cache.clear()
     computeContentSize()
     setNeedsLayout()
     layoutSubviews()

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -278,15 +278,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
   }
 
-  /// The layout algorithm simply lays out the view in linear order vertically
-  /// based on the views index inside `subviewsInLayoutOrder`. This is invoked
-  /// when a view changes size or origin. It also scales the frame of scroll views
-  /// in order to keep dequeuing for table and collection views.
-
-  @objc func injected() {
-
-  }
-
   internal func compare(_ lhs: CGSize, to rhs: CGSize) -> Bool {
     return (abs(lhs.height - rhs.height) <= 0.001)
   }

--- a/Sources/iOS/FamilScrollView+iOS.swift
+++ b/Sources/iOS/FamilScrollView+iOS.swift
@@ -1,0 +1,105 @@
+import UIKit
+
+extension FamilyScrollView {
+  internal func runLayoutSubviewsAlgorithm() {
+    if cache.isEmpty {
+      var yOffsetOfCurrentSubview: CGFloat = 0.0
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+        let insets = spaceManager.customInsets(for: view)
+        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+          continue
+        }
+
+        var frame = scrollView.frame
+        var contentOffset = scrollView.contentOffset
+
+        if self.contentOffset.y < yOffsetOfCurrentSubview {
+          contentOffset.y = insets.top
+          frame.origin.y = floor(yOffsetOfCurrentSubview)
+        } else {
+          contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
+          frame.origin.y = floor(self.contentOffset.y)
+        }
+
+        let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
+        let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+
+        //        frame.size.width = max(frame.size.width, self.frame.size.width)
+        if scrollView is FamilyWrapperView {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        } else {
+          newHeight = fmin(documentView.frame.height, newHeight)
+        }
+
+        let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height ||
+          self.contentOffset.y != frame.minY
+
+        if shouldModifyContentOffset {
+          if !compare(scrollView.contentOffset, to: contentOffset) {
+            scrollView.contentOffset.y = contentOffset.y
+          }
+        } else {
+          frame.origin.y = yOffsetOfCurrentSubview
+        }
+
+        frame.size.width = self.frame.size.width - insets.left - insets.right
+        frame.size.height = newHeight
+
+        if scrollView.frame != frame {
+          scrollView.frame = frame
+        }
+
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
+        var cachedOrigin = frame.origin
+        cachedOrigin.y += insets.top
+        cache.add(entry: FamilyCacheEntry(view: view,
+                                          origin: cachedOrigin,
+                                          contentSize: scrollView.contentSize))
+      }
+      computeContentSize()
+    } else {
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+        guard let entry = cache.entry(for: view) else { continue }
+        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+          continue
+        }
+
+        var frame = scrollView.frame
+        var contentOffset = scrollView.contentOffset
+
+        if self.contentOffset.y < entry.origin.y {
+          contentOffset.y = 0.0
+          frame.origin.y = floor(entry.origin.y)
+        } else {
+          contentOffset.y = self.contentOffset.y - entry.origin.y
+          frame.origin.y = floor(self.contentOffset.y)
+        }
+
+        let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)
+        let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+
+        if scrollView is FamilyWrapperView {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        } else {
+          newHeight = fmin(documentView.frame.height, newHeight)
+        }
+
+        let shouldScroll = self.contentOffset.y >= entry.origin.y && self.contentOffset.y <= entry.maxY
+
+        if shouldScroll {
+          scrollView.contentOffset.y = contentOffset.y
+        }
+
+        frame.size.height = newHeight
+
+        if scrollView.frame != frame {
+          scrollView.frame = frame
+        }
+      }
+    }
+  }
+}

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -169,8 +169,8 @@ public class FamilyScrollView: NSScrollView {
         subviewsInLayoutOrder.append(scrollView)
       }
     }
-    runLayoutSubviewsAlgorithm()
     cache.clear()
+    runLayoutSubviewsAlgorithm()
   }
 
   func didRemoveScrollViewToContainer(_ subview: NSView) {

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -66,7 +66,7 @@ extension FamilyScrollView {
       }
       computeContentSize()
     } else {
-      for (offset, scrollView) in subviewsInLayoutOrder.enumerated() where scrollView.isHidden == false {
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
         guard let entry = cache.entry(for: view) else { continue }
         if (scrollView as? FamilyWrapperView)?.view.isHidden == true {

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -1,0 +1,116 @@
+import UIKit
+
+extension FamilyScrollView {
+  internal func runLayoutSubviewsAlgorithm() {
+    if cache.isEmpty {
+      var yOffsetOfCurrentSubview: CGFloat = 0.0
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+        let insets = spaceManager.customInsets(for: view)
+        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+          continue
+        }
+
+        var frame = scrollView.frame
+        var contentOffset = scrollView.contentOffset
+
+        if self.contentOffset.y < yOffsetOfCurrentSubview {
+          contentOffset.y = insets.top
+          frame.origin.y = floor(yOffsetOfCurrentSubview)
+        } else {
+          contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
+          frame.origin.y = floor(self.contentOffset.y)
+        }
+
+        let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
+        let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+
+        if scrollView is FamilyWrapperView {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        } else {
+          newHeight = fmin(documentView.frame.height, newHeight)
+        }
+
+        if newHeight == 0 {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        }
+
+        let shouldScroll = (self.contentOffset.y >= frame.origin.y &&
+          self.contentOffset.y <= scrollView.frame.maxY) &&
+          frame.height >= documentView.frame.height
+
+        if shouldScroll {
+          scrollView.contentOffset.y = contentOffset.y
+        } else {
+          frame.origin.y = yOffsetOfCurrentSubview
+        }
+
+        frame.size.width = self.frame.size.width - insets.left - insets.right
+        frame.size.height = newHeight
+
+        if scrollView.frame != frame {
+          scrollView.frame = frame
+        }
+
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
+        var cachedOrigin = frame.origin
+        cachedOrigin.y += insets.top
+        cache.add(entry: FamilyCacheEntry(view: view,
+                                          origin: cachedOrigin,
+                                          contentSize: scrollView.contentSize))
+      }
+      computeContentSize()
+    } else {
+      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+        guard let entry = cache.entry(for: view) else { continue }
+        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+          continue
+        }
+
+        var frame = scrollView.frame
+        var contentOffset = scrollView.contentOffset
+
+        if self.contentOffset.y < entry.origin.y {
+          contentOffset.y = 0.0
+          frame.origin.y = floor(entry.origin.y)
+        } else {
+          contentOffset.y = self.contentOffset.y - entry.origin.y
+          frame.origin.y = floor(self.contentOffset.y)
+        }
+
+        let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)
+        let remainingContentHeight = fmax(entry.contentSize.height - contentOffset.y, 0.0)
+        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+
+        if scrollView is FamilyWrapperView {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        } else {
+          newHeight = fmin(documentView.frame.height, newHeight)
+        }
+
+        if newHeight == 0 {
+          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+        }
+
+        let shouldScroll = (self.contentOffset.y > frame.origin.y &&
+          self.contentOffset.y < entry.maxY) &&
+          frame.height >= documentView.frame.height
+
+        if shouldScroll {
+          scrollView.contentOffset.y = contentOffset.y
+        } else {
+          frame.origin.y = entry.origin.y
+        }
+
+        frame.size.height = newHeight
+
+        if compare(scrollView.frame.origin, to: frame.origin) ||
+          compare(scrollView.frame.size, to: frame.size) {
+          scrollView.frame = frame
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Because of the focus engine on tvOS, the algorithm cannot be optimized both for iOS and tvOS as they have different requirements. This PR splits the algorithm so that each platform (tvOS and iOS) have their own optimized implementation.