### PR TITLE
Fix UI stutter on ios

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.0"
+  s.version          = "0.9.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS/FamilScrollView+iOS.swift
+++ b/Sources/iOS/FamilScrollView+iOS.swift
@@ -71,10 +71,10 @@ extension FamilyScrollView {
 
         if self.contentOffset.y < entry.origin.y {
           contentOffset.y = 0.0
-          frame.origin.y = floor(entry.origin.y)
+          frame.origin.y = abs(entry.origin.y)
         } else {
           contentOffset.y = self.contentOffset.y - entry.origin.y
-          frame.origin.y = floor(self.contentOffset.y)
+          frame.origin.y = abs(self.contentOffset.y)
         }
 
         let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)
@@ -87,10 +87,12 @@ extension FamilyScrollView {
           newHeight = fmin(documentView.frame.height, newHeight)
         }
 
-        let shouldScroll = self.contentOffset.y >= entry.origin.y && self.contentOffset.y <= entry.maxY
+        let shouldScroll = self.contentOffset.y >= entry.origin.y &&
+          self.contentOffset.y <= entry.maxY &&
+          scrollView.contentOffset.y == abs(contentOffset.y)
 
         if shouldScroll {
-          scrollView.contentOffset.y = contentOffset.y
+          scrollView.contentOffset.y = abs(contentOffset.y)
         }
 
         frame.size.height = newHeight


### PR DESCRIPTION
With a keen eye, you can sometimes see small UI-stutters when scrolling a large list if you look at the top or bottom of the screen. This had to do with not using absolute numbers and settings the content offset even if they are the same. We now have additional checks for these kinds of situations and the new values that get aggregated to the frame and offset now use `abs()`