### PR TITLE
Various macOS fixes

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.1"
+  s.version          = "0.9.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -223,7 +223,6 @@ public class FamilyScrollView: NSScrollView {
   private func runLayoutSubviewsAlgorithm() {
     if cache.isEmpty {
       var yOffsetOfCurrentSubview: CGFloat = 0.0
-      var offset = 0
       for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
         var shouldResize: Bool = true
@@ -276,7 +275,6 @@ public class FamilyScrollView: NSScrollView {
 
 
         yOffsetOfCurrentSubview += contentSize.height + insets.top + insets.bottom
-        offset += 1
         var cachedOrigin = frame.origin
         cachedOrigin.y += insets.top
         cache.add(entry: FamilyCacheEntry(view: scrollView.documentView!, origin: cachedOrigin, contentSize: contentSize))

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -87,6 +87,13 @@ public class FamilyScrollView: NSScrollView {
 
     NotificationCenter.default.addObserver(
       self,
+      selector: #selector(windowDidResize(_:)),
+      name: NSSplitView.didResizeSubviewsNotification,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
       selector: #selector(windowDidEndLiveResize(_:)),
       name: NSWindow.didEndLiveResizeNotification,
       object: nil

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -228,11 +228,12 @@ public class FamilyScrollView: NSScrollView {
         var shouldResize: Bool = true
         let contentSize: CGSize = contentSizeForView(view, shouldResize: &shouldResize)
         let insets = spaceManager.customInsets(for: view)
+        yOffsetOfCurrentSubview += insets.top
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
         if self.contentOffset.y < yOffsetOfCurrentSubview {
-          contentOffset.y = insets.top
+          contentOffset.y = 0
           frame.origin.y = floor(yOffsetOfCurrentSubview)
         } else {
           contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
@@ -243,6 +244,7 @@ public class FamilyScrollView: NSScrollView {
         let remainingContentHeight = fmax(contentSize.height - contentOffset.y, 0.0)
         var newHeight: CGFloat = fmin(remainingBoundsHeight, remainingContentHeight)
 
+        frame.origin.x = insets.left
         frame.size.width = max(frame.size.width, self.frame.size.width)
 
         let shouldModifyContentOffset = contentOffset.y - contentInsets.top <= scrollView.contentSize.height + (contentInsets.top * 2) ||
@@ -272,12 +274,8 @@ public class FamilyScrollView: NSScrollView {
         )
 
         scrollView.contentView.scroll(contentOffset)
-
-
-        yOffsetOfCurrentSubview += contentSize.height + insets.top + insets.bottom
-        var cachedOrigin = frame.origin
-        cachedOrigin.y += insets.top
-        cache.add(entry: FamilyCacheEntry(view: scrollView.documentView!, origin: cachedOrigin, contentSize: contentSize))
+        yOffsetOfCurrentSubview += contentSize.height + insets.bottom
+        cache.add(entry: FamilyCacheEntry(view: scrollView.documentView!, origin: frame.origin, contentSize: contentSize))
       }
       computeContentSize()
     } else {

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -102,7 +102,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     scrollView.frame = view.bounds
 
     if let insets = insets {
-      setCustomInsets(insets, for: view)
+      setCustomInsets(insets, for: subview)
     }
   }
 

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -63,8 +63,6 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
 
   public func addChild(_ childController: ViewController, customInsets insets: Insets? = nil, height: CGFloat) {
     addChild(childController)
-    childController.view.translatesAutoresizingMaskIntoConstraints = true
-    childController.view.autoresizingMask = [.width]
     childController.view.frame.size.height = height
     childController.view.frame.size.width = view.bounds.width
     scrollView.frame = view.bounds

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -6,7 +6,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   public lazy var scrollView: FamilyScrollView = .init()
   /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
-  var registry = [ViewController: View]()
+  private(set) public var registry = [ViewController: View]()
   var observer: NSKeyValueObservation?
   var eventHandlerKeyDown: Any?
 

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -24,6 +24,7 @@ class FamilyWrapperView: NSScrollView {
     self.hasVerticalScroller = false
     self.postsBoundsChangedNotifications = true
     self.verticalScrollElasticity = .none
+    self.drawsBackground = false
 
     self.frameObserver = wrappedView.observe(\.frame, options: [.new, .old], changeHandler: { [weak self] (_, value) in
       guard value.newValue?.size != value.oldValue?.size else { return }


### PR DESCRIPTION
- Fix bug with the wrong view being used when setting custom insets
- Observe changes when split views changes
- Improve layout algorithm by using the correct offsets when using custom insets
- Remove drawing backgrounds in the `FamilyWrapperView`
- Make the registry publicly available