### PR TITLE
Use yOffsetOfCurrentSubview as cached origin

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.3"
+  s.version          = "0.9.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		BDAC587021B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
 		BDAC587121B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
 		BDAC588321BA613A00412766 /* FamilyScrollView+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588221BA613A00412766 /* FamilyScrollView+tvOS.swift */; };
-		BDAC588521BA61CA00412766 /* FamilScrollView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588421BA61CA00412766 /* FamilScrollView+iOS.swift */; };
+		BDAC588521BA61CA00412766 /* FamilyScrollView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588421BA61CA00412766 /* FamilyScrollView+iOS.swift */; };
 		BDAC588921BA63B800412766 /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588821BA63B800412766 /* FamilyScrollViewTests.swift */; };
 		BDEE36352043394E00120E35 /* FamilyWrapperViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE36342043394E00120E35 /* FamilyWrapperViewTests.swift */; };
 		BDEE3637204369F200120E35 /* FamilyContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEE3636204369F200120E35 /* FamilyContentViewTests.swift */; };
@@ -112,7 +112,7 @@
 		BD7629B920349C2500C917BB /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BD7629BD20349CA300C917BB /* FamilyFriendly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyFriendly.swift; sourceTree = "<group>"; };
 		BDAC588221BA613A00412766 /* FamilyScrollView+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FamilyScrollView+tvOS.swift"; sourceTree = "<group>"; };
-		BDAC588421BA61CA00412766 /* FamilScrollView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FamilScrollView+iOS.swift"; sourceTree = "<group>"; };
+		BDAC588421BA61CA00412766 /* FamilyScrollView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FamilyScrollView+iOS.swift"; sourceTree = "<group>"; };
 		BDAC588821BA63B800412766 /* FamilyScrollViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyScrollViewTests.swift; sourceTree = "<group>"; };
 		BDEE36342043394E00120E35 /* FamilyWrapperViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyWrapperViewTests.swift; sourceTree = "<group>"; };
 		BDEE3636204369F200120E35 /* FamilyContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyContentViewTests.swift; sourceTree = "<group>"; };
@@ -265,7 +265,7 @@
 		BDAC588021BA611100412766 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				BDAC588421BA61CA00412766 /* FamilScrollView+iOS.swift */,
+				BDAC588421BA61CA00412766 /* FamilyScrollView+iOS.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -710,7 +710,7 @@
 				BD5A80422030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
 				BD5A803E2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
 				BDAC586E21B9916E00412766 /* FamilyCache.swift in Sources */,
-				BDAC588521BA61CA00412766 /* FamilScrollView+iOS.swift in Sources */,
+				BDAC588521BA61CA00412766 /* FamilyScrollView+iOS.swift in Sources */,
 				BD535E162079269200AA2EC4 /* FamilySpaceManager.swift in Sources */,
 				BD5A803C2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80442030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -50,12 +50,11 @@ extension FamilyScrollView {
           scrollView.frame = frame
         }
 
-        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
-        var cachedOrigin = frame.origin
-        cachedOrigin.y += insets.top
         cache.add(entry: FamilyCacheEntry(view: view,
-                                          origin: cachedOrigin,
+                                          origin: CGPoint(x: frame.origin.x,
+                                                          y: yOffsetOfCurrentSubview),
                                           contentSize: scrollView.contentSize))
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
       }
       computeContentSize()
     } else {

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -15,6 +15,7 @@ extension FamilyScrollView {
           continue
         }
 
+        yOffsetOfCurrentSubview += insets.top
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
@@ -57,12 +58,11 @@ extension FamilyScrollView {
           scrollView.frame = frame
         }
 
-        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
-        var cachedOrigin = frame.origin
-        cachedOrigin.y += insets.top
         cache.add(entry: FamilyCacheEntry(view: view,
-                                          origin: cachedOrigin,
+                                          origin: CGPoint(x: frame.origin.x,
+                                                          y: yOffsetOfCurrentSubview),
                                           contentSize: scrollView.contentSize))
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
       }
       computeContentSize()
     } else {


### PR DESCRIPTION
Use yOffsetOfCurrentSubview instead of computed frame value as it is agnostic to the current content offset of the scroll view.