### PR TITLE
Optimize tvOS algorithm and fix layout glitch

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.4"
+  s.version          = "0.9.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -98,7 +98,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   /// - Parameter scrollView: The scroll view that should be configured
   ///                         and observed.
   func didAddScrollViewToContainer(_ scrollView: UIScrollView) {
-    defer { cache.clear() }
     scrollView.autoresizingMask = [.flexibleWidth]
 
     guard documentView.subviews.index(of: scrollView) != nil else {
@@ -113,9 +112,8 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       configureScrollView(scrollView)
     }
 
-    computeContentSize()
+    cache.clear()
     setNeedsLayout()
-    layoutSubviews()
   }
 
   /// Removes the observer for any view that gets removed from the view heirarcy.
@@ -136,11 +134,8 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       configureScrollView(scrollView)
     }
 
-    cache.clear()
-    computeContentSize()
-    setNeedsLayout()
-    layoutSubviews()
     spaceManager.removeView(subview)
+    cache.clear()
   }
 
   /// Configures all scroll view in view heirarcy if they are allowed to scroll or not.

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -114,6 +114,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
     cache.clear()
     setNeedsLayout()
+    layoutIfNeeded()
   }
 
   /// Removes the observer for any view that gets removed from the view heirarcy.
@@ -136,6 +137,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
     spaceManager.removeView(subview)
     cache.clear()
+    layoutIfNeeded()
   }
 
   /// Configures all scroll view in view heirarcy if they are allowed to scroll or not.

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -104,6 +104,11 @@ extension FamilyScrollView {
           scrollView.contentOffset.y = contentOffset.y
         } else {
           frame.origin.y = entry.origin.y
+          // Reset content offset to avoid setting offsets that
+          // look liked `clipsToBounds` bugs.
+          if self.contentOffset.y < entry.maxY {
+            scrollView.contentOffset.y = 0
+          }
         }
 
         frame.size.height = newHeight


### PR DESCRIPTION
There were a few scenarios where the layout algorithm never properly resets the content offset to 0 even if the view was on screen. This should fix that UI-glitch by checking if the current content offset is less than the max y of the underlying view. That way we know that the view is on screen and should have a content y offset of y.