### PR TITLE
Allows `FamilyWrapperView`'s to always scroll

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.5"
+  s.version          = "0.9.6"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -90,7 +90,7 @@ extension FamilyScrollView {
           self.contentOffset.y <= entry.maxY &&
           scrollView.contentOffset.y == abs(contentOffset.y)
 
-        if shouldScroll {
+        if shouldScroll || scrollView is FamilyWrapperView {
           scrollView.contentOffset.y = abs(contentOffset.y)
         }
 

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -100,7 +100,7 @@ extension FamilyScrollView {
           self.contentOffset.y < entry.maxY) &&
           frame.height >= documentView.frame.height
 
-        if shouldScroll {
+        if shouldScroll || scrollView is FamilyWrapperView {
           scrollView.contentOffset.y = contentOffset.y
         } else {
           frame.origin.y = entry.origin.y


### PR DESCRIPTION
Improves the scrolling experience when adding regular views into the Family view hierarchy.