### PR TITLE
Improve using insets on tvOS and iOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.6"
+  s.version          = "0.9.7"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -211,8 +211,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   }
 
   public func setCustomInsets(_ insets: Insets, for view: View) {
-    view.frame.origin.x = insets.left
-    view.frame.size.width = self.view.frame.size.width - insets.left - insets.right
     scrollView.setCustomInsets(insets, for: view)
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -38,7 +38,7 @@ class FamilyWrapperView: UIScrollView {
 
     addSubview(view)
     alwaysBounceVertical = true
-    clipsToBounds = true
+    clipsToBounds = false
     if #available(iOS 11.0, tvOS 11.0, *) {
       contentInsetAdjustmentBehavior = .never
     }

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -11,6 +11,8 @@ extension FamilyScrollView {
           continue
         }
 
+        yOffsetOfCurrentSubview += insets.top
+
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
@@ -43,6 +45,7 @@ extension FamilyScrollView {
           frame.origin.y = yOffsetOfCurrentSubview
         }
 
+        frame.origin.x = insets.left
         frame.size.width = self.frame.size.width - insets.left - insets.right
         frame.size.height = newHeight
 
@@ -54,7 +57,7 @@ extension FamilyScrollView {
                                           origin: CGPoint(x: frame.origin.x,
                                                           y: yOffsetOfCurrentSubview),
                                           contentSize: scrollView.contentSize))
-        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
       computeContentSize()
     } else {

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -16,6 +16,7 @@ extension FamilyScrollView {
         }
 
         yOffsetOfCurrentSubview += insets.top
+
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
@@ -51,6 +52,7 @@ extension FamilyScrollView {
           frame.origin.y = yOffsetOfCurrentSubview
         }
 
+        frame.origin.x = insets.left
         frame.size.width = self.frame.size.width - insets.left - insets.right
         frame.size.height = newHeight
 
@@ -62,7 +64,7 @@ extension FamilyScrollView {
                                           origin: CGPoint(x: frame.origin.x,
                                                           y: yOffsetOfCurrentSubview),
                                           contentSize: scrollView.contentSize))
-        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom + insets.top
+        yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
       computeContentSize()
     } else {


### PR DESCRIPTION
The previous implementation was a bit buggy when using custom insets on iOS (and some hidden issues on tvOS) because it applied the insets twice. Plus the absolute y coordinate for the view did not take the top inset into account when running the algorithm on iOS.

Also, the wrapper view no longer clips the wrapped view as this has undesired side-effects when using insets.