### PR TITLE
Improve moving children

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.9.7"
+  s.version          = "0.10.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -96,7 +96,7 @@
 		BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };
 		BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyScrollView.swift; sourceTree = "<group>"; };
 		BD4C7FE320349B030037D3E5 /* FamilyDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyDocumentView.swift; sourceTree = "<group>"; };
-		BD535E142078DEFC00AA2EC4 /* Family.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Family.podspec; sourceTree = "<group>"; };
+		BD535E142078DEFC00AA2EC4 /* Family.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Family.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilySpaceManager.swift; sourceTree = "<group>"; };
 		BD5A80362030A9D9006A5EBB /* FamilyDocumentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyDocumentView.swift; sourceTree = "<group>"; };
 		BD5A80372030A9D9006A5EBB /* FamilyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };

--- a/FamilyTests/iOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/iOS/FamilyViewControllerTests.swift
@@ -109,4 +109,19 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(familyViewController.scrollView.contentInset.bottom,
                    familyViewController.scrollView.scrollIndicatorInsets.bottom)
   }
+
+  func testViewControllersInLayoutOrder() {
+    let familyViewController = FamilyViewController()
+
+    let controller1 = UIViewController()
+    let controller2 = UIViewController()
+    let controller3 = UIViewController()
+
+    familyViewController.addChild(controller1, at: 0)
+    familyViewController.addChild(controller3, at: 1)
+    familyViewController.addChild(controller2, at: 0)
+
+    XCTAssertEqual(familyViewController.viewControllersInLayoutOrder(),
+                   [controller2, controller1, controller3])
+  }
 }

--- a/FamilyTests/macOS/FamilyViewControllerTests.swift
+++ b/FamilyTests/macOS/FamilyViewControllerTests.swift
@@ -102,4 +102,20 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(viewController.view.frame.size.width, familyViewController.view.frame.width)
     XCTAssertEqual(viewController.view.frame.size.height, 200)
   }
+
+  func testViewControllersInLayoutOrder() {
+    let familyViewController = FamilyViewController()
+    let controller1 = MockViewController()
+    let controller2 = MockViewController()
+    let controller3 = MockViewController()
+
+    familyViewController.addChild(controller1, at: 0)
+    familyViewController.addChild(controller3, at: 1)
+    familyViewController.addChild(controller2, at: 0)
+
+    let expected = [controller2, controller1, controller3]
+    let result = familyViewController.viewControllersInLayoutOrder()
+
+    XCTAssertEqual(result, expected)
+  }
 }

--- a/Sources/Shared/FamilyFriendly.swift
+++ b/Sources/Shared/FamilyFriendly.swift
@@ -3,8 +3,8 @@ import Foundation
 
 protocol FamilyFriendly: class {
   func addChild(_ childController: ViewController)
-  func addChild(_ childController: ViewController, customInsets: Insets?, height: CGFloat)
-  func addChild<T: ViewController>(_ childController: T, customInsets: Insets?, view closure: (T) -> View)
+  func addChild(_ childController: ViewController, at index: Int?, customInsets: Insets?, height: CGFloat)
+  func addChild<T: ViewController>(_ childController: T, at index: Int?, customInsets: Insets?, view closure: (T) -> View)
   func addChildren(_ childControllers: ViewController ...)
 
   func purgeRemovedViews()

--- a/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
@@ -26,6 +26,22 @@ public class FamilyDocumentView: UIView {
   /// - Parameter view: The view to be added.
   ///                   After being added, this view appears on top of any other subviews.
   open override func addSubview(_ view: UIView) {
+    let subview = wrapViewIfNeeded(view)
+    super.addSubview(subview)
+
+    guard let scrollView = subview as? UIScrollView else { return }
+
+    delegate?.familyDocumentView(self, didAddScrollView: scrollView)
+  }
+
+  public override func insertSubview(_ view: UIView, at index: Int) {
+    let subview = wrapViewIfNeeded(view)
+    super.insertSubview(subview, at: index)
+    guard let scrollView = subview as? UIScrollView else { return }
+    delegate?.familyDocumentView(self, didAddScrollView: scrollView)
+  }
+
+  private func wrapViewIfNeeded(_ view: UIView) -> UIView {
     let subview: UIView
 
     switch view {
@@ -38,17 +54,7 @@ public class FamilyDocumentView: UIView {
       subview = wrapper
     }
 
-    super.addSubview(subview)
-
-    guard let scrollView = subview as? UIScrollView else { return }
-
-    delegate?.familyDocumentView(self, didAddScrollView: scrollView)
-  }
-
-  public override func insertSubview(_ view: UIView, at index: Int) {
-    super.insertSubview(view, at: index)
-    guard let scrollView = view as? UIScrollView else { return }
-    delegate?.familyDocumentView(self, didAddScrollView: scrollView)
+    return subview
   }
 
   /// Tells the view that a subview is about to be removed.

--- a/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
@@ -45,6 +45,12 @@ public class FamilyDocumentView: UIView {
     delegate?.familyDocumentView(self, didAddScrollView: scrollView)
   }
 
+  public override func insertSubview(_ view: UIView, at index: Int) {
+    super.insertSubview(view, at: index)
+    guard let scrollView = view as? UIScrollView else { return }
+    delegate?.familyDocumentView(self, didAddScrollView: scrollView)
+  }
+
   /// Tells the view that a subview is about to be removed.
   /// Calls `FamilyScrollView` in order to remove the observers
   /// on the view.

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -172,6 +172,12 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   private func observeView(view: UIScrollView) {
     guard view.superview == documentView else { return }
 
+    for observer in observers.filter({ $0.view === view }) {
+      if let index = observers.index(where: { $0 == observer }) {
+        observers.remove(at: index)
+      }
+    }
+
     let contentSizeObserver = view.observe(\.contentSize, options: [.initial, .new, .old], changeHandler: { [weak self] (scrollView, value) in
       guard let strongSelf = self,
         let newValue = value.newValue,

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -191,7 +191,10 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  public func addView(_ subview: View, at index: Int? = nil, withHeight height: CGFloat? = nil, customInsets insets: Insets? = nil) {
+  public func addView(_ subview: View,
+                      at index: Int? = nil,
+                      withHeight height: CGFloat? = nil,
+                      customInsets insets: Insets? = nil) {
     if let height = height {
       subview.frame.size.width = view.bounds.size.width
       subview.frame.size.height = height
@@ -207,6 +210,23 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
+  public func viewControllersInLayoutOrder() -> [ViewController] {
+    var viewControllers = [ViewController]()
+    var temporaryContainer = [View: ViewController]()
+
+    for entry in registry {
+      temporaryContainer[entry.value.view] = entry.key
+    }
+
+    for view in scrollView.documentView.scrollViews {
+      let lookupView = (view as? FamilyWrapperView)?.view ?? view
+      guard let controller = temporaryContainer[lookupView] else { continue }
+      viewControllers.append(controller)
+    }
+
+    return viewControllers
+  }
+
   public func customInsets(for view: View) -> Insets {
     return scrollView.customInsets(for: view)
   }
@@ -216,10 +236,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   }
 
   private func addOrInsertView(_ view: UIView, at index: Int? = nil) {
-    if view.superview != nil {
-      view.removeFromSuperview()
-    }
-
     if let index = index, index < scrollView.documentView.subviews.count {
       scrollView.documentView.insertSubview(view, at: index)
     } else {

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -72,7 +72,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
         scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
         scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
         scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-      ])
+        ])
     } else {
       if #available(iOS 9.0, *) {
         constraints.append(contentsOf: [
@@ -80,7 +80,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
           scrollView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
           scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
           scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
+          ])
       }
     }
     NSLayoutConstraint.activate(constraints)
@@ -93,34 +93,34 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     purgeRemovedViews()
     childController.willMove(toParent: self)
     super.addChild(childController)
-
-    let childViewControllerView: UIView
-
-    switch childController {
-    case let collectionViewController as UICollectionViewController:
-      if let collectionView = collectionViewController.collectionView {
-        scrollView.documentView.addSubview(collectionView)
-        childViewControllerView = collectionView
-      } else {
-        assertionFailure("Unable to resolve collection view from controller.")
-        return
-      }
-    case let tableViewController as UITableViewController:
-      scrollView.documentView.addSubview(tableViewController.tableView)
-      childViewControllerView = tableViewController.tableView
-    default:
-      scrollView.documentView.addSubview(childController.view)
-      childViewControllerView = childController.view
+    let newView = viewToAdd(from: childController)
+    if #available(iOS 11.0, *, tvOS 11.0, *) {
+      (newView as? UIScrollView)?.contentInsetAdjustmentBehavior = .never
     }
+    addOrInsertView(newView)
+    childController.didMove(toParent: self)
+    registry[childController] = (newView, observe(childController))
+    scrollView.purgeWrapperViews()
+  }
 
+  open func addChild(_ childController: UIViewController, at index: Int?) {
+    purgeRemovedViews()
+    childController.willMove(toParent: self)
+    super.addChild(childController)
+    let view = viewToAdd(from: childController)
+    addOrInsertView(view, at: index)
     if #available(iOS 11.0, *, tvOS 11.0, *) {
       (childController.view as? UIScrollView)?.contentInsetAdjustmentBehavior = .never
     }
 
     childController.didMove(toParent: self)
-
-    registry[childController] = (childViewControllerView, observe(childController))
+    registry[childController] = (view, observe(childController))
     scrollView.purgeWrapperViews()
+  }
+
+  open func moveChild(_ childController: UIViewController, to index: Int) {
+    let view = viewToAdd(from: childController)
+    addOrInsertView(view, at: index)
   }
 
   /// Adds the specified view controller as a child of the current view controller.
@@ -128,10 +128,10 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// - Parameters:
   ///   - childController: The view controller to be added as a child.
   ///   - height: The height that the child controllers should be constrained to.
-  open func addChild(_ childController: UIViewController, customInsets: Insets? = nil, height: CGFloat) {
+  open func addChild(_ childController: UIViewController, at index: Int? = nil, customInsets: Insets? = nil, height: CGFloat) {
     childController.willMove(toParent: self)
     super.addChild(childController)
-    scrollView.documentView.addSubview(childController.view)
+    addView(childController.view, at: index, withHeight: height, customInsets: customInsets)
     childController.didMove(toParent: self)
     childController.view.translatesAutoresizingMaskIntoConstraints = true
     childController.view.frame.size.width = view.frame.size.width
@@ -155,6 +155,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   ///   - closure: A closure used to resolve a view other than `.view` on controller used
   ///              to render the view controller.
   public func addChild<T: UIViewController>(_ childController: T,
+                                            at index: Int? = nil,
                                             customInsets insets: Insets? = nil,
                                             view closure: (T) -> UIView) {
     childController.willMove(toParent: self)
@@ -168,7 +169,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       (childView as? UIScrollView)?.contentInsetAdjustmentBehavior = .never
     }
 
-    addView(childView, customInsets: insets)
+    addView(childView, at: index, customInsets: insets)
     childController.didMove(toParent: self)
     registry[childController] = (childView, observe(childController))
     scrollView.purgeWrapperViews()
@@ -190,7 +191,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  public func addView(_ subview: View, withHeight height: CGFloat? = nil, customInsets insets: Insets? = nil) {
+  public func addView(_ subview: View, at index: Int? = nil, withHeight height: CGFloat? = nil, customInsets insets: Insets? = nil) {
     if let height = height {
       subview.frame.size.width = view.bounds.size.width
       subview.frame.size.height = height
@@ -198,7 +199,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       subview.frame.size.width = view.bounds.width
     }
 
-    scrollView.documentView.addSubview(subview)
+    addOrInsertView(subview, at: index)
     scrollView.frame = view.bounds
 
     if let insets = insets {
@@ -212,6 +213,38 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
 
   public func setCustomInsets(_ insets: Insets, for view: View) {
     scrollView.setCustomInsets(insets, for: view)
+  }
+
+  private func addOrInsertView(_ view: UIView, at index: Int? = nil) {
+    if view.superview != nil {
+      view.removeFromSuperview()
+    }
+
+    if let index = index, index < scrollView.documentView.subviews.count {
+      scrollView.documentView.insertSubview(view, at: index)
+    } else {
+      scrollView.documentView.addSubview(view)
+    }
+  }
+
+  private func viewToAdd(from childController: UIViewController) -> View {
+    let view: UIView
+
+    switch childController {
+    case let collectionViewController as UICollectionViewController:
+      if let collectionView = collectionViewController.collectionView {
+        view = collectionView
+      } else {
+        assertionFailure("Unable to resolve collection view from controller.")
+        return childController.view
+      }
+    case let tableViewController as UITableViewController:
+      view = tableViewController.tableView
+    default:
+      view = childController.view
+    }
+
+    return view
   }
 
   /// Remove stray views from view hierarcy.

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -211,8 +211,7 @@ public class FamilyScrollView: NSScrollView {
 
   private func rebuildSubviewsInLayoutOrder(exceptSubview: View? = nil) {
     subviewsInLayoutOrder.removeAll()
-    let filteredSubviews = familyDocumentView.scrollViews.filter({ !($0 === exceptSubview) })
-    subviewsInLayoutOrder = filteredSubviews
+    subviewsInLayoutOrder = familyDocumentView.subviewsInLayoutOrder.filter({ !($0 === exceptSubview) })
   }
 
   private func validateScrollView(_ scrollView: NSScrollView) -> Bool {


### PR DESCRIPTION
You can now add an index when adding view controllers if you want the view controller to appear in a specific place in the view hierarchy.

Adds a new function in FamilyViewController to get the view controllers in the order they appear on the screen called `viewControllersInLayoutOrder`