### PR TITLE
Call layoutViews() after setting custom insets

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.11.0"
+  s.version          = "0.11.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -239,6 +239,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   public func setCustomInsets(_ insets: Insets, for view: View) {
     spaceManager.setCustomInsets(insets, for: view)
     cache.clear()
+    layoutViews()
   }
 
   /// Remove wrapper views that don't own their underlaying views.


### PR DESCRIPTION
When setting custom insets we need to invalidate the cache in order to set new coordinates to the target view.