### PR TITLE
Add state to cache to make sure it is done before running the algorithm

### DIFF
--- a/Sources/Shared/FamilyCache.swift
+++ b/Sources/Shared/FamilyCache.swift
@@ -1,9 +1,13 @@
 import CoreGraphics
 
 class FamilyCache: NSObject {
+  enum State {
+    case empty, isRunning, isFinished
+  }
+
+  var state: State = .empty
   var contentSize: CGSize = .zero
   var storage = [View: FamilyCacheEntry]()
-  var isEmpty: Bool { return storage.isEmpty }
   override init() {}
 
   func add(entry: FamilyCacheEntry) {
@@ -14,7 +18,8 @@ class FamilyCache: NSObject {
     return storage[view]
   }
 
-  func clear() {
+  func invalidate() {
     storage.removeAll()
+    state = .empty
   }
 }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -6,7 +6,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     get { return spaceManager.insets }
     set {
       spaceManager.insets = newValue
-      cache.clear()
+      cache.invalidate()
     }
   }
   /// A collection of scroll views that is used to order the views on screen.
@@ -113,7 +113,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       configureScrollView(scrollView)
     }
 
-    cache.clear()
+    cache.invalidate()
     setNeedsLayout()
     layoutIfNeeded()
   }
@@ -137,7 +137,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
 
     spaceManager.removeView(subview)
-    cache.clear()
+    cache.invalidate()
     layoutIfNeeded()
   }
 
@@ -187,7 +187,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       }
 
       if self?.compare(newValue, to: oldValue) == false {
-        strongSelf.cache.clear()
+        strongSelf.cache.invalidate()
         strongSelf.layoutViews()
       }
     })
@@ -200,7 +200,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       }
 
       if newValue != oldValue {
-        self?.cache.clear()
+        self?.cache.invalidate()
         self?.layoutViews()
       }
     })
@@ -238,7 +238,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
   public func setCustomInsets(_ insets: Insets, for view: View) {
     spaceManager.setCustomInsets(insets, for: view)
-    cache.clear()
+    cache.invalidate()
     layoutViews()
   }
 

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -2,7 +2,10 @@ import UIKit
 
 extension FamilyScrollView {
   internal func runLayoutSubviewsAlgorithm() {
-    if cache.isEmpty {
+    guard cache.state != .isRunning else { return }
+
+    if cache.state == .empty {
+      cache.state = .isRunning
       var yOffsetOfCurrentSubview: CGFloat = 0.0
       for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
@@ -60,6 +63,7 @@ extension FamilyScrollView {
         yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
       computeContentSize()
+      cache.state = .isFinished
     } else {
       for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -34,14 +34,14 @@ class FamilyWrapperView: NSScrollView {
     self.alphaObserver = view.observe(\.alphaValue, options: [.initial, .new, .old]) { [weak self] (_, value) in
       guard value.newValue != value.oldValue, let newValue = value.newValue else { return }
       self?.alphaValue = newValue
-      (self?.enclosingScrollView as? FamilyScrollView)?.cache.clear()
+      (self?.enclosingScrollView as? FamilyScrollView)?.cache.invalidate()
       self?.layoutViews()
     }
 
     self.hiddenObserver = view.observe(\.isHidden, options: [.initial, .new, .old]) { [weak self] (_, value) in
       guard value.newValue != value.oldValue, let newValue = value.newValue else { return }
       self?.isHidden = newValue
-      (self?.enclosingScrollView as? FamilyScrollView)?.cache.clear()
+      (self?.enclosingScrollView as? FamilyScrollView)?.cache.invalidate()
       self?.layoutViews()
     }
   }

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -6,7 +6,10 @@ extension FamilyScrollView {
   /// when a view changes size or origin. It also scales the frame of scroll views
   /// in order to keep dequeuing for table and collection views.
   internal func runLayoutSubviewsAlgorithm() {
-    if cache.isEmpty {
+    guard cache.state != .isRunning else { return }
+
+    if cache.state == .empty {
+      cache.state = .isRunning
       var yOffsetOfCurrentSubview: CGFloat = 0.0
       for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
@@ -67,6 +70,7 @@ extension FamilyScrollView {
         yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
       computeContentSize()
+      cache.state = .isFinished
     } else {
       for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
         let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView


### PR DESCRIPTION
This improves the stability of the layout algorithm by adding `state` to the cache. It works as a guard for running the layout algorithm before the caching mechanism is done storing the view hierarchies values. 