### PR TITLE
Optimize layout algorithms

### DIFF
--- a/FamilyTests/tvOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/tvOS/FamilyScrollViewTests.swift
@@ -104,7 +104,7 @@ class FamilyScrollViewTests: XCTestCase {
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + scrollView.insets.bottom), size: size))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500 + scrollView.insets.bottom * 2), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750 + scrollView.insets.bottom * 3),
-                                                   size: CGSize(width: size.width, height: size.height - scrollView.insets.bottom * 3)))
+                                                   size: CGSize(width: size.width, height: size.height)))
 
     XCTAssertEqual(scrollView.contentSize.height, 1040)
 

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -37,17 +37,7 @@ extension FamilyScrollView {
           newHeight = fmin(documentView.frame.height, newHeight)
         }
 
-        let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height ||
-          self.contentOffset.y != frame.minY
-
-        if shouldModifyContentOffset {
-          if !compare(scrollView.contentOffset, to: contentOffset) {
-            scrollView.contentOffset.y = contentOffset.y
-          }
-        } else {
-          frame.origin.y = yOffsetOfCurrentSubview
-        }
-
+        frame.origin.y = yOffsetOfCurrentSubview
         frame.origin.x = insets.left
         frame.size.width = self.frame.size.width - insets.left - insets.right
         frame.size.height = newHeight
@@ -64,49 +54,50 @@ extension FamilyScrollView {
       }
       computeContentSize()
       cache.state = .isFinished
-    } else {
-      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
-        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
-        guard let entry = cache.entry(for: view) else { continue }
-        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
-          continue
-        }
+    }
 
-        var frame = scrollView.frame
-        var contentOffset = scrollView.contentOffset
+    for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+      let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+      guard let entry = cache.entry(for: view) else { continue }
+      if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+        continue
+      }
 
-        if self.contentOffset.y < entry.origin.y {
-          contentOffset.y = 0.0
-          frame.origin.y = abs(entry.origin.y)
-        } else {
-          contentOffset.y = self.contentOffset.y - entry.origin.y
-          frame.origin.y = abs(self.contentOffset.y)
-        }
+      var frame = scrollView.frame
+      var contentOffset = scrollView.contentOffset
 
-        let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)
-        let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
-        var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+      if self.contentOffset.y < entry.origin.y {
+        contentOffset.y = 0.0
+        frame.origin.y = abs(entry.origin.y)
+      } else {
+        contentOffset.y = self.contentOffset.y - entry.origin.y
+        frame.origin.y = abs(self.contentOffset.y)
+      }
 
-        if scrollView is FamilyWrapperView {
-          newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
-        } else {
-          newHeight = fmin(documentView.frame.height, newHeight)
-        }
+      let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)
+      let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+      var newHeight: CGFloat = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
 
-        let shouldScroll = self.contentOffset.y >= entry.origin.y &&
-          self.contentOffset.y <= entry.maxY &&
-          scrollView.contentOffset.y == abs(contentOffset.y)
+      if scrollView is FamilyWrapperView {
+        newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+      } else {
+        newHeight = fmin(documentView.frame.height, newHeight)
+      }
 
-        if shouldScroll || scrollView is FamilyWrapperView {
-          scrollView.contentOffset.y = abs(contentOffset.y)
-        }
+      let shouldScroll = self.contentOffset.y >= entry.origin.y &&
+        self.contentOffset.y <= entry.maxY &&
+        scrollView.contentOffset.y == abs(contentOffset.y)
 
-        frame.size.height = newHeight
+      if shouldScroll || scrollView is FamilyWrapperView {
+        scrollView.contentOffset.y = abs(contentOffset.y)
+      }
 
-        if scrollView.frame != frame {
-          scrollView.frame = frame
-        }
+      frame.size.height = newHeight
+
+      if scrollView.frame != frame {
+        scrollView.frame = frame
       }
     }
+
   }
 }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -258,11 +258,7 @@ public class FamilyScrollView: NSScrollView {
 
         if newHeight == 0 {
           newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
-          if shouldModifyContentOffset && shouldResize {
-            scrollView.contentOffset.y = contentOffset.y
-          } else {
-            frame.origin.y = yOffsetOfCurrentSubview
-          }
+          frame.origin.y = yOffsetOfCurrentSubview
         } else if remainingContentHeight < contentSize.height {
           frame.origin.y = self.contentOffset.y - (contentSize.height - remainingContentHeight)
           shouldResize = false
@@ -279,8 +275,6 @@ public class FamilyScrollView: NSScrollView {
           to: scrollView
         )
 
-        scrollView.contentView.scroll(contentOffset)
-
         cache.add(entry: FamilyCacheEntry(view: scrollView.documentView!,
                                           origin: CGPoint(x: frame.origin.x, y: yOffsetOfCurrentSubview),
                                           contentSize: contentSize))
@@ -288,49 +282,49 @@ public class FamilyScrollView: NSScrollView {
       }
       computeContentSize()
       cache.state = .isFinished
-    } else {
-      let currentOffset = self.contentOffset.y + contentView.contentInsets.top
-      let documentHeight = self.documentView!.frame.size.height
+    }
 
-      // Reached the top
-      guard currentOffset >= 0 else { return }
+    let currentOffset = self.contentOffset.y + contentView.contentInsets.top
+    let documentHeight = self.documentView!.frame.size.height
 
-      // Reached the end
-      guard self.documentVisibleRect.maxY <= documentHeight else { return }
+    // Reached the top
+    guard currentOffset >= 0 else { return }
 
-      for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
-        guard let entry = cache.entry(for: scrollView.documentView!) else { continue }
-        var frame = scrollView.frame
-        var contentOffset = scrollView.contentOffset
+    // Reached the end
+    guard self.documentVisibleRect.maxY <= documentHeight else { return }
 
-        if self.contentOffset.y < entry.origin.y {
-          contentOffset.y = 0
-          frame.origin.y = floor(entry.origin.y)
-        } else {
-          contentOffset.y = self.contentOffset.y - entry.origin.y
-          frame.origin.y = floor(self.contentOffset.y)
-        }
+    for scrollView in subviewsInLayoutOrder where validateScrollView(scrollView) {
+      guard let entry = cache.entry(for: scrollView.documentView!) else { continue }
+      var frame = scrollView.frame
+      var contentOffset = scrollView.contentOffset
 
-        let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)
-        let remainingContentHeight = fmax(entry.contentSize.height - contentOffset.y, 0.0)
-        var newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
+      if self.contentOffset.y < entry.origin.y {
+        contentOffset.y = 0
+        frame.origin.y = floor(entry.origin.y)
+      } else {
+        contentOffset.y = self.contentOffset.y - entry.origin.y
+        frame.origin.y = floor(self.contentOffset.y)
+      }
 
-        if newHeight == 0 {
-          newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
-        }
+      let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)
+      let remainingContentHeight = fmax(entry.contentSize.height - contentOffset.y, 0.0)
+      var newHeight: CGFloat = floor(fmin(remainingBoundsHeight, remainingContentHeight))
 
-        // Only scroll if the views content offset is less than its content size height
-        // and if the frame is less than the content size height.
-        let shouldScroll = contentOffset.y <= entry.contentSize.height &&
-          frame.size.height < entry.contentSize.height
+      if newHeight == 0 {
+        newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
+      }
 
-        if shouldScroll {
-          scrollView.contentView.scroll(contentOffset)
-          scrollView.frame.origin.y = frame.origin.y
-          scrollView.frame.size.height = newHeight
-        } else {
-          scrollView.frame.origin.y = entry.origin.y
-        }
+      // Only scroll if the views content offset is less than its content size height
+      // and if the frame is less than the content size height.
+      let shouldScroll = contentOffset.y <= entry.contentSize.height &&
+        frame.size.height < entry.contentSize.height
+
+      if shouldScroll {
+        scrollView.contentView.scroll(contentOffset)
+        scrollView.frame.origin.y = frame.origin.y
+        scrollView.frame.size.height = newHeight
+      } else {
+        scrollView.frame.origin.y = entry.origin.y
       }
     }
   }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -253,9 +253,6 @@ public class FamilyScrollView: NSScrollView {
         frame.origin.x = insets.left
         frame.size.width = max(frame.size.width, self.frame.size.width)
 
-        let shouldModifyContentOffset = contentOffset.y - contentInsets.top <= scrollView.contentSize.height + (contentInsets.top * 2) ||
-          self.contentOffset.y != frame.minY
-
         if newHeight == 0 {
           newHeight = fmin(contentView.frame.height, scrollView.contentSize.height)
           frame.origin.y = yOffsetOfCurrentSubview

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -45,16 +45,7 @@ extension FamilyScrollView {
           newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
         }
 
-        let shouldScroll = (self.contentOffset.y >= frame.origin.y &&
-          self.contentOffset.y <= scrollView.frame.maxY) &&
-          frame.height >= documentView.frame.height
-
-        if shouldScroll {
-          scrollView.contentOffset.y = contentOffset.y
-        } else {
-          frame.origin.y = yOffsetOfCurrentSubview
-        }
-
+        frame.origin.y = yOffsetOfCurrentSubview
         frame.origin.x = insets.left
         frame.size.width = self.frame.size.width - insets.left - insets.right
         frame.size.height = newHeight
@@ -71,59 +62,60 @@ extension FamilyScrollView {
       }
       computeContentSize()
       cache.state = .isFinished
-    } else {
-      for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
-        let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
-        guard let entry = cache.entry(for: view) else { continue }
-        if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
-          continue
-        }
+    }
 
-        var frame = scrollView.frame
-        var contentOffset = scrollView.contentOffset
+    for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
+      let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
+      guard let entry = cache.entry(for: view) else { continue }
+      if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
+        continue
+      }
 
-        if self.contentOffset.y < entry.origin.y {
-          contentOffset.y = 0.0
-          frame.origin.y = floor(entry.origin.y)
-        } else {
-          contentOffset.y = self.contentOffset.y - entry.origin.y
-          frame.origin.y = floor(self.contentOffset.y)
-        }
+      var frame = scrollView.frame
+      var contentOffset = scrollView.contentOffset
 
-        let remainingBoundsHeight = bounds.maxY - entry.origin.y
-        let remainingContentHeight = entry.contentSize.height - contentOffset.y
-        var newHeight: CGFloat = fmin(documentView.frame.height, scrollView.contentSize.height)
+      if self.contentOffset.y < entry.origin.y {
+        contentOffset.y = 0.0
+        frame.origin.y = floor(entry.origin.y)
+      } else {
+        contentOffset.y = self.contentOffset.y - entry.origin.y
+        frame.origin.y = floor(self.contentOffset.y)
+      }
 
-        if remainingBoundsHeight <= -self.frame.size.height {
-          newHeight = 0
-        }
+      let remainingBoundsHeight = bounds.maxY - entry.origin.y
+      let remainingContentHeight = entry.contentSize.height - contentOffset.y
+      var newHeight: CGFloat = fmin(documentView.frame.height, scrollView.contentSize.height)
 
-        if remainingContentHeight <= -self.frame.size.height {
-          newHeight = 0
-        }
+      if remainingBoundsHeight <= -self.frame.size.height {
+        newHeight = 0
+      }
 
-        let shouldScroll = (self.contentOffset.y > frame.origin.y &&
-          self.contentOffset.y < entry.maxY) &&
-          frame.height >= documentView.frame.height
+      if remainingContentHeight <= -self.frame.size.height {
+        newHeight = 0
+      }
 
-        if shouldScroll || scrollView is FamilyWrapperView {
-          scrollView.contentOffset.y = contentOffset.y
-        } else {
-          frame.origin.y = entry.origin.y
-          // Reset content offset to avoid setting offsets that
-          // look liked `clipsToBounds` bugs.
-          if self.contentOffset.y < entry.maxY {
-            scrollView.contentOffset.y = 0
-          }
-        }
+      let shouldScroll = (self.contentOffset.y > frame.origin.y &&
+        self.contentOffset.y < entry.maxY) &&
+        frame.height >= documentView.frame.height
 
-        frame.size.height = newHeight
-
-        if compare(scrollView.frame.origin, to: frame.origin) ||
-          compare(scrollView.frame.size, to: frame.size) {
-          scrollView.frame = frame
+      if shouldScroll || scrollView is FamilyWrapperView {
+        scrollView.contentOffset.y = contentOffset.y
+      } else {
+        frame.origin.y = entry.origin.y
+        // Reset content offset to avoid setting offsets that
+        // look liked `clipsToBounds` bugs.
+        if self.contentOffset.y < entry.maxY {
+          scrollView.contentOffset.y = 0
         }
       }
+
+      frame.size.height = newHeight
+
+      if compare(scrollView.frame.origin, to: frame.origin) ||
+        compare(scrollView.frame.size, to: frame.size) {
+        scrollView.frame = frame
+      }
     }
+
   }
 }


### PR DESCRIPTION
This PR refactors the layout algorithms to always run the optimized version for setting the actual size to the views. The old algorithm is still used for constructing a cache. The biggest difference to the implementation is that instead of doing `if else`, we now use `if` to construct the cache and then carry on to layout the views afterward. That saves us one additional layout pass before getting the correct size. It will also hinder rendering more views than necessary during the first layout-pass.


 