### PR TITLE
Use round on frame.origin.y in layout algorithm

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.11.3"
+  s.version          = "0.11.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -21,10 +21,10 @@ extension FamilyScrollView {
 
         if self.contentOffset.y < yOffsetOfCurrentSubview {
           contentOffset.y = insets.top
-          frame.origin.y = floor(yOffsetOfCurrentSubview)
+          frame.origin.y = round(yOffsetOfCurrentSubview)
         } else {
           contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
-          frame.origin.y = floor(self.contentOffset.y)
+          frame.origin.y = round(self.contentOffset.y)
         }
 
         let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
@@ -68,10 +68,10 @@ extension FamilyScrollView {
 
       if self.contentOffset.y < entry.origin.y {
         contentOffset.y = 0.0
-        frame.origin.y = abs(entry.origin.y)
+        frame.origin.y = abs(round(entry.origin.y))
       } else {
         contentOffset.y = self.contentOffset.y - entry.origin.y
-        frame.origin.y = abs(self.contentOffset.y)
+        frame.origin.y = abs(round(self.contentOffset.y))
       }
 
       let remainingBoundsHeight = fmax(bounds.maxY - entry.origin.y, 0.0)

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -243,10 +243,10 @@ public class FamilyScrollView: NSScrollView {
 
         if self.contentOffset.y < yOffsetOfCurrentSubview {
           contentOffset.y = 0
-          frame.origin.y = floor(yOffsetOfCurrentSubview)
+          frame.origin.y = round(yOffsetOfCurrentSubview)
         } else {
           contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
-          frame.origin.y = floor(self.contentOffset.y)
+          frame.origin.y = round(self.contentOffset.y)
         }
 
         let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)
@@ -300,10 +300,10 @@ public class FamilyScrollView: NSScrollView {
 
       if self.contentOffset.y < entry.origin.y {
         contentOffset.y = 0
-        frame.origin.y = floor(entry.origin.y)
+        frame.origin.y = round(entry.origin.y)
       } else {
         contentOffset.y = self.contentOffset.y - entry.origin.y
-        frame.origin.y = floor(self.contentOffset.y)
+        frame.origin.y = round(self.contentOffset.y)
       }
 
       let remainingBoundsHeight = fmax(self.documentVisibleRect.maxY - frame.minY, 0.0)

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -25,10 +25,10 @@ extension FamilyScrollView {
 
         if self.contentOffset.y < yOffsetOfCurrentSubview {
           contentOffset.y = insets.top
-          frame.origin.y = floor(yOffsetOfCurrentSubview)
+          frame.origin.y = round(yOffsetOfCurrentSubview)
         } else {
           contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
-          frame.origin.y = floor(self.contentOffset.y)
+          frame.origin.y = round(self.contentOffset.y)
         }
 
         let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
@@ -76,10 +76,10 @@ extension FamilyScrollView {
 
       if self.contentOffset.y < entry.origin.y {
         contentOffset.y = 0.0
-        frame.origin.y = floor(entry.origin.y)
+        frame.origin.y = round(entry.origin.y)
       } else {
         contentOffset.y = self.contentOffset.y - entry.origin.y
-        frame.origin.y = floor(self.contentOffset.y)
+        frame.origin.y = round(self.contentOffset.y)
       }
 
       let remainingBoundsHeight = bounds.maxY - entry.origin.y


### PR DESCRIPTION
To avoid rendering subpixels, all layout algorithms will now `round` the origin y coordinate to make sure that this does not happen. It fixes a rendering issue that could appear on iPhone X > phones.

`tvOS` and `macOS` have also been adjusted to use `round` instead of `floor`.

Co-Authored-By: Sindre Moen <sindrenm@users.noreply.github.com>