### PR TITLE
Feature visibility related methods

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.11.5"
+  s.version          = "0.12.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -9,6 +9,13 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       cache.invalidate()
     }
   }
+
+  /// The current viewport
+  public var documentVisibleRect: CGRect {
+    return CGRect(origin: contentOffset,
+                  size: frame.size)
+  }
+
   /// A collection of scroll views that is used to order the views on screen.
   /// This collection is used by the layout algorithm that render the views and
   /// the order that they should appear.

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -15,6 +15,9 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
 
+  //  The current viewport of the scroll view
+  public var documentVisibleRect: CGRect { return scrollView.documentVisibleRect }
+
   public var safeAreaLayoutConstraints: Bool = true {
     didSet { configureConstraints() }
   }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -236,6 +236,25 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
+  /// Check if a view controller is visible on screen.
+  ///
+  /// - Parameter viewController: The target view controller
+  /// - Returns: True if the view controller is visible on screen
+  public func viewControllerIsVisible(_ viewController: UIViewController) -> Bool {
+    return registry[viewController]?.view.frame.intersects(documentVisibleRect) ?? false
+  }
+
+  /// Check if a view controller is fully visible on screen.
+  ///
+  /// - Parameter viewController: The target view controller
+  /// - Returns: True if the view controller is fully visible on screen
+  public func viewControllerIsFullyVisible(_ viewController: UIViewController) -> Bool {
+    guard let item = registry[viewController] else { return false }
+    let convertedFrame = scrollView.documentView.convert(item.view.frame,
+                                                         to: scrollView.documentView)
+    return documentVisibleRect.contains(convertedFrame)
+  }
+
   // MARK: - Private methods
 
   /// Configure constraints for the scroll view.


### PR DESCRIPTION
- Adds convenience methods on FamilyViewController and FamilyScrollView to get the current viewport for the scroll view. 
The computed property is called `documentVisibleRect`.

- Adds `viewControllerIsVisible(_ viewController: UIViewController)` which verifies if a view controller is visible on screen. It also features a method called `viewControllerIsFullyVisible(_ viewController: UIViewController)` which checks that the view controller is fully visible.