### PR TITLE
Add attributesForViewController on FamilyViewController

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.12.0"
+  s.version          = "0.13.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BD02F56721B43E5E006ECE48 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
-		BD02F56921B43E7F006ECE48 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
+		BD02F56921B43E7F006ECE48 /* FamilyViewControllerAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyViewControllerAttributes.swift */; };
 		BD0FCCD620794AFA00D813EC /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
 		BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
 		BD2236E32034B12A00C465E4 /* NSScrollView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */; };
@@ -45,8 +45,8 @@
 		BD7629C020349CA300C917BB /* FamilyFriendly.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7629BD20349CA300C917BB /* FamilyFriendly.swift */; };
 		BDAC586E21B9916E00412766 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
 		BDAC586F21B9916E00412766 /* FamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56621B43E5E006ECE48 /* FamilyCache.swift */; };
-		BDAC587021B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
-		BDAC587121B9916E00412766 /* FamilyCacheEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */; };
+		BDAC587021B9916E00412766 /* FamilyViewControllerAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyViewControllerAttributes.swift */; };
+		BDAC587121B9916E00412766 /* FamilyViewControllerAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD02F56821B43E7F006ECE48 /* FamilyViewControllerAttributes.swift */; };
 		BDAC588321BA613A00412766 /* FamilyScrollView+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588221BA613A00412766 /* FamilyScrollView+tvOS.swift */; };
 		BDAC588521BA61CA00412766 /* FamilyScrollView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588421BA61CA00412766 /* FamilyScrollView+iOS.swift */; };
 		BDAC588921BA63B800412766 /* FamilyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAC588821BA63B800412766 /* FamilyScrollViewTests.swift */; };
@@ -89,7 +89,7 @@
 
 /* Begin PBXFileReference section */
 		BD02F56621B43E5E006ECE48 /* FamilyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyCache.swift; sourceTree = "<group>"; };
-		BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyCacheEntry.swift; sourceTree = "<group>"; };
+		BD02F56821B43E7F006ECE48 /* FamilyViewControllerAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewControllerAttributes.swift; sourceTree = "<group>"; };
 		BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScrollView+Extensions.swift"; sourceTree = "<group>"; };
 		BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyWrapperView.swift; sourceTree = "<group>"; };
 		BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyClipView.swift; sourceTree = "<group>"; };
@@ -197,7 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				BD02F56621B43E5E006ECE48 /* FamilyCache.swift */,
-				BD02F56821B43E7F006ECE48 /* FamilyCacheEntry.swift */,
+				BD02F56821B43E7F006ECE48 /* FamilyViewControllerAttributes.swift */,
 				BD7629B920349C2500C917BB /* TypeAlias.swift */,
 				BD7629BD20349CA300C917BB /* FamilyFriendly.swift */,
 				BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */,
@@ -678,7 +678,7 @@
 				BD5A803D2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80452030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629C020349CA300C917BB /* FamilyFriendly.swift in Sources */,
-				BDAC587121B9916E00412766 /* FamilyCacheEntry.swift in Sources */,
+				BDAC587121B9916E00412766 /* FamilyViewControllerAttributes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -715,7 +715,7 @@
 				BD5A803C2030A9D9006A5EBB /* FamilyDocumentView.swift in Sources */,
 				BD5A80442030A9D9006A5EBB /* CALayer+Extensions.swift in Sources */,
 				BD7629BE20349CA300C917BB /* FamilyFriendly.swift in Sources */,
-				BDAC587021B9916E00412766 /* FamilyCacheEntry.swift in Sources */,
+				BDAC587021B9916E00412766 /* FamilyViewControllerAttributes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -741,7 +741,7 @@
 				BD4C7FE420349B030037D3E5 /* FamilyDocumentView.swift in Sources */,
 				BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */,
 				BD02F56721B43E5E006ECE48 /* FamilyCache.swift in Sources */,
-				BD02F56921B43E7F006ECE48 /* FamilyCacheEntry.swift in Sources */,
+				BD02F56921B43E7F006ECE48 /* FamilyViewControllerAttributes.swift in Sources */,
 				BD0FCCD620794AFA00D813EC /* FamilySpaceManager.swift in Sources */,
 				BD4C7FE020349AA10037D3E5 /* FamilyViewController.swift in Sources */,
 				BD7629BB20349C2C00C917BB /* TypeAlias.swift in Sources */,

--- a/Sources/Shared/FamilyCache.swift
+++ b/Sources/Shared/FamilyCache.swift
@@ -7,14 +7,14 @@ class FamilyCache: NSObject {
 
   var state: State = .empty
   var contentSize: CGSize = .zero
-  var storage = [View: FamilyCacheEntry]()
+  var storage = [View: FamilyViewControllerAttributes]()
   override init() {}
 
-  func add(entry: FamilyCacheEntry) {
+  func add(entry: FamilyViewControllerAttributes) {
     storage[entry.view] = entry
   }
 
-  func entry(for view: View) -> FamilyCacheEntry? {
+  func entry(for view: View) -> FamilyViewControllerAttributes? {
     return storage[view]
   }
 

--- a/Sources/Shared/FamilyViewControllerAttributes.swift
+++ b/Sources/Shared/FamilyViewControllerAttributes.swift
@@ -1,6 +1,6 @@
 import CoreGraphics
 
-class FamilyCacheEntry: NSObject {
+public class FamilyViewControllerAttributes: NSObject {
   let view: View
   let origin: CGPoint
   let contentSize: CGSize

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -223,19 +223,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  /// Remove stray views from view hierarchy.
-  func purgeRemovedViews() {
-    for (controller, container) in registry where controller.parent == nil {
-      if container.view.superview is FamilyWrapperView {
-        container.view.superview?.removeFromSuperview()
-      }
-
-      container.view.removeFromSuperview()
-      container.observer.invalidate()
-      registry.removeValue(forKey: controller)
-    }
-  }
-
   /// Check if a view controller is visible on screen.
   ///
   /// - Parameter viewController: The target view controller
@@ -253,6 +240,29 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     let convertedFrame = scrollView.documentView.convert(item.view.frame,
                                                          to: scrollView.documentView)
     return documentVisibleRect.contains(convertedFrame)
+  }
+
+  /// Extract attributes for a view controller.
+  ///
+  /// - Parameter viewController: The target view controller.
+  /// - Returns: An optional `FamilyViewControllerAttributes` for the target view controller.
+  public func attributesForViewController(_ viewController: UIViewController) -> FamilyViewControllerAttributes? {
+    guard let entry = registry[viewController],
+      let attributes = scrollView.cache.entry(for: entry.view) else { return nil }
+    return attributes
+  }
+
+  /// Remove stray views from view hierarchy.
+  func purgeRemovedViews() {
+    for (controller, container) in registry where controller.parent == nil {
+      if container.view.superview is FamilyWrapperView {
+        container.view.superview?.removeFromSuperview()
+      }
+
+      container.view.removeFromSuperview()
+      container.observer.invalidate()
+      registry.removeValue(forKey: controller)
+    }
   }
 
   // MARK: - Private methods

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -46,10 +46,10 @@ extension FamilyScrollView {
           scrollView.frame = frame
         }
 
-        cache.add(entry: FamilyCacheEntry(view: view,
-                                          origin: CGPoint(x: frame.origin.x,
-                                                          y: yOffsetOfCurrentSubview),
-                                          contentSize: scrollView.contentSize))
+        cache.add(entry: FamilyViewControllerAttributes(view: view,
+                                                        origin: CGPoint(x: frame.origin.x,
+                                                                        y: yOffsetOfCurrentSubview),
+                                                        contentSize: scrollView.contentSize))
         yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
       computeContentSize()

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -275,9 +275,9 @@ public class FamilyScrollView: NSScrollView {
           to: scrollView
         )
 
-        cache.add(entry: FamilyCacheEntry(view: scrollView.documentView!,
-                                          origin: CGPoint(x: frame.origin.x, y: yOffsetOfCurrentSubview),
-                                          contentSize: contentSize))
+        cache.add(entry: FamilyViewControllerAttributes(view: scrollView.documentView!,
+                                                        origin: CGPoint(x: frame.origin.x, y: yOffsetOfCurrentSubview),
+                                                        contentSize: contentSize))
         yOffsetOfCurrentSubview += contentSize.height + insets.bottom
       }
       computeContentSize()

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -6,6 +6,10 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   public lazy var scrollView: FamilyScrollView = .init()
   /// The scroll view constraints.
   public var constraints = [NSLayoutConstraint]()
+
+  //  The current viewport of the scroll view
+  public var documentVisibleRect: CGRect { return scrollView.documentVisibleRect }
+
   private(set) public var registry = [ViewController: View]()
   var observer: NSKeyValueObservation?
   var eventHandlerKeyDown: Any?
@@ -195,6 +199,35 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     scrollView.layoutViews(withDuration: 0.25) {
       completion?(self)
     }
+  }
+
+  /// Check if a view controller is visible on screen.
+  ///
+  /// - Parameter viewController: The target view controller
+  /// - Returns: True if the view controller is visible on screen
+  public func viewControllerIsVisible(_ viewController: NSViewController) -> Bool {
+    return registry[viewController]?.frame.intersects(documentVisibleRect) ?? false
+  }
+
+  /// Check if a view controller is fully visible on screen.
+  ///
+  /// - Parameter viewController: The target view controller
+  /// - Returns: True if the view controller is fully visible on screen
+  public func viewControllerIsFullyVisible(_ viewController: NSViewController) -> Bool {
+    guard let view = registry[viewController] else { return false }
+    let convertedFrame = scrollView.familyDocumentView.convert(view.frame,
+                                                         to: scrollView.documentView)
+    return documentVisibleRect.contains(convertedFrame)
+  }
+
+  /// Extract attributes for a view controller.
+  ///
+  /// - Parameter viewController: The target view controller.
+  /// - Returns: An optional `FamilyViewControllerAttributes` for the target view controller.
+  public func attributesForViewController(_ viewController: NSViewController) -> FamilyViewControllerAttributes? {
+    guard let view = registry[viewController],
+      let attributes = scrollView.cache.entry(for: view) else { return nil }
+    return attributes
   }
 
   /// Remove stray views from view hierarchy.

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -54,10 +54,10 @@ extension FamilyScrollView {
           scrollView.frame = frame
         }
 
-        cache.add(entry: FamilyCacheEntry(view: view,
-                                          origin: CGPoint(x: frame.origin.x,
-                                                          y: yOffsetOfCurrentSubview),
-                                          contentSize: scrollView.contentSize))
+        cache.add(entry: FamilyViewControllerAttributes(view: view,
+                                                        origin: CGPoint(x: frame.origin.x,
+                                                                        y: yOffsetOfCurrentSubview),
+                                                        contentSize: scrollView.contentSize))
         yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
       computeContentSize()


### PR DESCRIPTION
Adds `attributesForViewController` on `FamilyViewController` to get the cache attributes for a view controller. It uses the layout algorithm cache to get the absolute values for the view controller.

`viewControllerIsVisible` and `viewControllerIsFullyVisible` are now avaiable on macOS.