### PR TITLE
Fix UI glitch on ios

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.13.0"
+  s.version          = "0.13.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/FamilyTests/iOS/FamilyScrollViewTests.swift
+++ b/FamilyTests/iOS/FamilyScrollViewTests.swift
@@ -135,7 +135,7 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 500), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 500), size: size))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
@@ -143,8 +143,8 @@ class FamilyScrollViewTests: XCTestCase {
     scrollView.setContentOffset(CGPoint(x: 0, y: 750), animated: false)
     scrollView.layoutViews()
 
-    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
-    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: size.width, height: 0)))
+    XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView3.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: CGSize(width: size.width, height: 0)))
     XCTAssertEqual(mockedScrollView4.frame, CGRect(origin: CGPoint(x: 0, y: 750), size: size))
   }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -216,7 +216,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
   /// Computes the content size for the collection view based on
   /// combined content size of all the underlaying scroll views.
-  internal func computeContentSize() {
+  internal func computeContentSize() -> CGSize {
     let computedHeight = subviewsInLayoutOrder
       .filter({ $0.isHidden == false || ($0 as? FamilyWrapperView)?.view.isHidden == false })
       .reduce(CGFloat(0), { value, view in
@@ -226,7 +226,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     let minimumContentHeight = bounds.height - (contentInset.top + contentInset.bottom)
     let height = fmax(computedHeight, minimumContentHeight)
 
-    contentSize = CGSize(width: bounds.size.width, height: height)
+    return CGSize(width: bounds.size.width, height: height)
   }
 
   /// This method will call the layout algorithm without duration

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -111,6 +111,5 @@ extension FamilyScrollView {
         scrollView.frame = frame
       }
     }
-
   }
 }

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -89,8 +89,21 @@ extension FamilyScrollView {
         self.contentOffset.y <= entry.maxY &&
         scrollView.contentOffset.y == abs(contentOffset.y)
 
-      if shouldScroll || scrollView is FamilyWrapperView {
-        scrollView.contentOffset.y = abs(contentOffset.y)
+      if scrollView is FamilyWrapperView {
+        if self.contentOffset.y < entry.origin.y {
+          scrollView.contentOffset.y = contentOffset.y
+        } else {
+          frame.origin.y = entry.origin.y
+        }
+      } else if shouldScroll {
+        scrollView.contentOffset.y = contentOffset.y
+      } else {
+        frame.origin.y = entry.origin.y
+        // Reset content offset to avoid setting offsets that
+        // look liked `clipsToBounds` bugs.
+        if self.contentOffset.y < entry.maxY {
+          scrollView.contentOffset.y = 0
+        }
       }
 
       frame.size.height = newHeight

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -86,8 +86,7 @@ extension FamilyScrollView {
       }
 
       let shouldScroll = self.contentOffset.y >= entry.origin.y &&
-        self.contentOffset.y <= entry.maxY &&
-        scrollView.contentOffset.y == abs(contentOffset.y)
+        self.contentOffset.y <= entry.maxY
 
       if scrollView is FamilyWrapperView {
         if self.contentOffset.y < entry.origin.y {

--- a/Sources/iOS/FamilyScrollView+iOS.swift
+++ b/Sources/iOS/FamilyScrollView+iOS.swift
@@ -52,8 +52,9 @@ extension FamilyScrollView {
                                                         contentSize: scrollView.contentSize))
         yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
-      computeContentSize()
+      cache.contentSize = computeContentSize()
       cache.state = .isFinished
+      contentSize = cache.contentSize
     }
 
     for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -280,7 +280,8 @@ public class FamilyScrollView: NSScrollView {
                                                         contentSize: contentSize))
         yOffsetOfCurrentSubview += contentSize.height + insets.bottom
       }
-      computeContentSize()
+      cache.contentSize = computeContentSize()
+      documentView?.frame.size = cache.contentSize
       cache.state = .isFinished
     }
 
@@ -363,7 +364,7 @@ public class FamilyScrollView: NSScrollView {
     }
   }
 
-  private func computeContentSize() {
+  private func computeContentSize() -> CGSize {
     let computedHeight: CGFloat = subviewsInLayoutOrder
       .filter({ validateScrollView($0) })
       .reduce(CGFloat(0), { value, view in
@@ -377,7 +378,6 @@ public class FamilyScrollView: NSScrollView {
       height -= contentInsets.top
     }
 
-    cache.contentSize = documentView!.frame.size
-    documentView?.frame.size = CGSize(width: bounds.size.width, height: height)
+    return CGSize(width: bounds.size.width, height: height)
   }
 }

--- a/Sources/tvOS/FamilyScrollView+tvOS.swift
+++ b/Sources/tvOS/FamilyScrollView+tvOS.swift
@@ -60,8 +60,9 @@ extension FamilyScrollView {
                                                         contentSize: scrollView.contentSize))
         yOffsetOfCurrentSubview += scrollView.contentSize.height + insets.bottom
       }
-      computeContentSize()
+      cache.contentSize = computeContentSize()
       cache.state = .isFinished
+      contentSize = cache.contentSize
     }
 
     for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {


### PR DESCRIPTION
Refactors the implementation to be better at handling inline scrollable views.
Still a bit unsure about removing one of the checks but in overall it does improve how things fit together.

The check I'm unsure about...
```swift
scrollView.contentOffset.y = abs(contentOffset.y)
```