### PR TITLE
Fix jumpy scroll when using reload data

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.13.1"
+  s.version          = "0.13.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -194,8 +194,12 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       }
 
       if self?.compare(newValue, to: oldValue) == false {
+        let contentOffset = strongSelf.contentOffset
         strongSelf.cache.invalidate()
         strongSelf.layoutViews()
+        if !strongSelf.isScrolling {
+          strongSelf.setContentOffset(contentOffset, animated: false)
+        }
       }
     })
 


### PR DESCRIPTION
This PR fixes a minor issue where the content offset can be slightly adjusted when using `reloadData`.
It simply saves the previous content offset before the update and sets it back after the layout algorithm is done invalidating and doing one render pass. If the user is scrolling, we opt-out from adjusting the offset as the user is now in control over the content offset.