### PR TITLE
Improve scrolling performance on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.13.2"
+  s.version          = "0.13.3"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -199,15 +199,6 @@ public class FamilyScrollView: NSScrollView {
     cache.invalidate()
   }
 
-  public override func scrollWheel(with event: NSEvent) {
-    super.scrollWheel(with: event)
-
-    isScrolling = !(event.deltaX == 0 && event.deltaY == 0) ||
-      !(event.phase == .ended || event.momentumPhase == .ended)
-
-    layoutViews(withDuration: 0.0)
-  }
-
   func wrapperViewDidChangeFrame(from fromValue: CGRect, to toValue: CGRect) {
     cache.invalidate()
     layoutViews(withDuration: 0.0, force: false)
@@ -324,7 +315,7 @@ public class FamilyScrollView: NSScrollView {
         scrollView.contentView.scroll(contentOffset)
         scrollView.frame.origin.y = frame.origin.y
         scrollView.frame.size.height = newHeight
-      } else {
+      } else if scrollView.frame.origin.y != entry.origin.y {
         scrollView.frame.origin.y = entry.origin.y
       }
     }


### PR DESCRIPTION
- 💻 Only set the frame on off-screen views if the origin is not the same.
- 💻 Refactor `contentViewBoundsDidChange` to not be invoked if the user is scrolling with the scroll wheel.