### PR TITLE
Improve rendering on tvOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.13.4"
+  s.version          = "0.13.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -210,7 +210,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         }
       }
     })
-
     observers.append(Observer(view: view, keyValueObservation: contentSizeObserver))
 
     let hiddenObserver = view.observe(\.isHidden, options: [.new, .old], changeHandler: { [weak self] (_, value) in

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -223,6 +223,18 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       }
     })
     observers.append(Observer(view: view, keyValueObservation: hiddenObserver))
+
+    let contentOffsetObserver = view.observe(\.contentOffset, options: [.new], changeHandler: { [weak self] (scrollView, value) in
+      guard let strongSelf = self, let newValue = value.newValue else {
+        return
+      }
+
+      if strongSelf.scrollViewIsHorizontal(scrollView), newValue.y != 0 {
+        scrollView.contentOffset.y = 0
+        strongSelf.layoutSubviews()
+      }
+    })
+    observers.append(Observer(view: view, keyValueObservation: contentOffsetObserver))
   }
 
   /// Computes the content size for the collection view based on

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -166,9 +166,17 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
     #else
     for scrollView in subviewsInLayoutOrder {
-      scrollView.isScrollEnabled = ((scrollView as? UICollectionView)?.collectionViewLayout as? UICollectionViewFlowLayout)?.scrollDirection == .horizontal
+      scrollView.isScrollEnabled = scrollViewIsHorizontal(scrollView)
     }
     #endif
+  }
+
+  /// Check if the scroll view is of horizontal nature.
+  ///
+  /// - Parameter scrollView: The target scroll view.
+  /// - Returns: `true` if the scroll view as scroll direction set to horizontal.
+  private func scrollViewIsHorizontal(_ scrollView: UIScrollView) -> Bool {
+    return ((scrollView as? UICollectionView)?.collectionViewLayout as? UICollectionViewFlowLayout)?.scrollDirection == .horizontal
   }
 
   /// Sets up observers for the view that gets added into the view heirarcy.


### PR DESCRIPTION
### Add `contentOffset` observer in `FamilyScrollView`

This observer will correct the current content offset of horizontal scroll views. The content offset should always be 0 for horizontal scroll views but when scrolling a collection of horizontal scroll views that recently got a frame, the system can set the content offset to a different value as the frame and content size are currently out-of-sync. On tvOS, the system wants to perform a scroll in order to make the current content visible, this is now prevented by using the observer.

This can also be fixed by manually adding the following to the scroll views delegate.

```swift
func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
  targetContentOffset.pointee.y = 0
}
```

However, this needs to be on the client and not inside of the framework which makes it error-prone as the developer implementing Family needs to know about this specific issue and more importantly, needs to know to implement it every time there is a need to add a horizontal scroll view in the current UI composition. This is a best effort solution to work around the system correcting the content offset even if the frame and content size are set to a sane and valid value.

The issue was discovered on tvOS.