### PR TITLE
Refactor FamilyWrapperView to avoid recursion

### DIFF
--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -21,7 +21,22 @@ class FamilyWrapperView: UIScrollView {
   required init(frame: CGRect, view: UIView) {
     self.view = view
     super.init(frame: frame)
+    autoresizesSubviews = false
+    addSubview(view)
+    alwaysBounceVertical = true
+    clipsToBounds = false
+    if #available(iOS 11.0, tvOS 11.0, *) {
+      contentInsetAdjustmentBehavior = .never
+    }
 
+    configureObservers()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func configureObservers() {
     frameObserver = view.observe(\.frame, options: [.initial, .new]) { [weak self] (view, value) in
       if let rect = value.newValue {
         self?.setWrapperFrameSize(rect)
@@ -35,17 +50,6 @@ class FamilyWrapperView: UIScrollView {
         self?.parentDocumentView?.familyScrollView?.layoutIfNeeded()
       }
     }
-
-    addSubview(view)
-    alwaysBounceVertical = true
-    clipsToBounds = false
-    if #available(iOS 11.0, tvOS 11.0, *) {
-      contentInsetAdjustmentBehavior = .never
-    }
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
   }
 
   /// Sets the size of the rectangle as the content size for the view.

--- a/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyWrapperView.swift
@@ -21,6 +21,10 @@ class FamilyWrapperView: UIScrollView {
   required init(frame: CGRect, view: UIView) {
     self.view = view
     super.init(frame: frame)
+    // Disable resizing of subviews to avoid recursion.
+    // The wrapper view should follow the `.view`'s size, not the
+    // otherway around. If this is set to `true` then there is
+    // a potential for the observers trigger a resizing recursion.
     autoresizesSubviews = false
     addSubview(view)
     alwaysBounceVertical = true

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -17,6 +17,10 @@ class FamilyWrapperView: NSScrollView {
   required init(frame frameRect: NSRect, wrappedView: NSView) {
     self.view = wrappedView
     super.init(frame: frameRect)
+    // Disable resizing of subviews to avoid recursion.
+    // The wrapper view should follow the `.view`'s size, not the
+    // otherway around. If this is set to `true` then there is
+    // a potential for the observers trigger a resizing recursion.
     self.autoresizesSubviews = false
     self.contentView = clipView
     self.documentView = wrappedView

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -17,6 +17,7 @@ class FamilyWrapperView: NSScrollView {
   required init(frame frameRect: NSRect, wrappedView: NSView) {
     self.view = wrappedView
     super.init(frame: frameRect)
+    self.autoresizesSubviews = false
     self.contentView = clipView
     self.documentView = wrappedView
     self.hasHorizontalScroller = true

--- a/Tests/iOS+tvOS/FamilyViewControllerTests.swift
+++ b/Tests/iOS+tvOS/FamilyViewControllerTests.swift
@@ -245,4 +245,24 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(familyViewController.viewControllersInLayoutOrder().compactMap({ $0.title }),
                    ["Controller 3", "Controller 1", "Controller 2"])
   }
+
+  func testChangingViewSize() {
+    let window = UIWindow(frame: .init(origin: .zero, size: CGSize(width: 375, height: 667)))
+    let familyViewController = FamilyViewController()
+    window.rootViewController = familyViewController
+    familyViewController.view.frame.size = CGSize(width: 375, height: 667)
+    familyViewController.prepareViewController()
+
+    let controller1 = UIViewController()
+    controller1.title = "Controller 1"
+    controller1.view.frame.size = CGSize(width: 375, height: 200)
+
+    familyViewController.addChild(controller1)
+
+    let wrapperView = controller1.view.superview
+    XCTAssertEqual(controller1.view.frame.size, wrapperView?.frame.size)
+
+    controller1.view.frame.size.height = 400
+    XCTAssertEqual(controller1.view.frame.size, wrapperView?.frame.size)
+  }
 }


### PR DESCRIPTION
FamilyWrapperView will no longer resize its subviews, instead it will monitor the wrapped view for changes and adapt to the underlaying views size.