### PR TITLE
Remove implicitly setting  isChildViewController to true in willMove(toParent:)

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.1"
+  s.version          = "0.14.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -90,11 +90,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     }
   }
 
-  open override func willMove(toParent parent: UIViewController?) {
-    super.willMove(toParent: parent)
-    isChildViewController = !(parent is UITabBarController) && !(parent is UINavigationController)
-  }
-
   // MARK: - Public methods
 
   /// Adds the specified view controller as a child of the current view controller.

--- a/Tests/iOS+tvOS/FamilyViewControllerTests.swift
+++ b/Tests/iOS+tvOS/FamilyViewControllerTests.swift
@@ -125,31 +125,6 @@ class FamilyViewControllerTests: XCTestCase {
                    [controller2, controller1, controller3])
   }
 
-  func testFamilyViewControllerAsChildViewController() {
-    let viewController = UIViewController()
-    let familyViewController = FamilyViewController()
-    familyViewController.willMove(toParent: viewController)
-    viewController.addChild(familyViewController)
-    XCTAssertTrue(familyViewController.isChildViewController)
-    XCTAssertFalse(familyViewController.scrollView.isScrollEnabled)
-
-    _ = UINavigationController(rootViewController: familyViewController)
-
-    XCTAssertFalse(familyViewController.isChildViewController)
-    XCTAssertTrue(familyViewController.scrollView.isScrollEnabled)
-
-    familyViewController.willMove(toParent: viewController)
-    viewController.addChild(familyViewController)
-    XCTAssertTrue(familyViewController.isChildViewController)
-    XCTAssertFalse(familyViewController.scrollView.isScrollEnabled)
-
-    let tabBarController = UITabBarController()
-    tabBarController.viewControllers = [familyViewController]
-
-    XCTAssertFalse(familyViewController.isChildViewController)
-    XCTAssertTrue(familyViewController.scrollView.isScrollEnabled)
-  }
-
   func testViewControllerIsVisibleMethods() {
     let familyViewController = FamilyViewController()
     familyViewController.view.frame.size = CGSize(width: 375, height: 667)


### PR DESCRIPTION
Setting `isChildViewController` in `willMove(toParent)` is not always compatible for real-world usage. `isChildViewController` is now an opt-in feature, it can be enabled by passing it in the init method or it can be enabled by changing the public var on `FamilyViewController`.