### PR TITLE
Opt-out from doing layout invocations when deallocating

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.2"
+  s.version          = "0.14.3"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -10,6 +10,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
   }
 
+  internal var isDeallocating: Bool = false
   internal var isChildViewController: Bool = false
 
   /// The current viewport
@@ -305,7 +306,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
                           completion: (() -> Void)? = nil) {
     guard isPerformingBatchUpdates == false else { return }
 
-    guard superview != nil else { return }
+    guard superview != nil, !isDeallocating else { return }
 
     // Make sure that wrapper views have the correct width
     // on their wrapped views.

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -41,6 +41,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   }
 
   deinit {
+    scrollView.isDeallocating = true
     children.forEach {
       $0.willMove(toParent: nil)
       $0.removeFromParent()

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -13,7 +13,7 @@ public class FamilyScrollView: NSScrollView {
 
   @objc(scrollEnabled)
   public var isScrollEnabled: Bool = true
-
+  internal var isDeallocating: Bool = false
   internal var isChildViewController: Bool = false
 
   var layoutIsRunning: Bool = false
@@ -52,7 +52,7 @@ public class FamilyScrollView: NSScrollView {
   public func layoutViews(withDuration duration: CFTimeInterval? = nil,
                           force: Bool = false,
                           completion: (() -> Void)? = nil) {
-    guard isPerformingBatchUpdates == false else { return }
+    guard isPerformingBatchUpdates == false, !isDeallocating else { return }
 
     guard !layoutIsRunning || !force else {
       return
@@ -250,8 +250,9 @@ public class FamilyScrollView: NSScrollView {
   }
 
   private func runLayoutSubviewsAlgorithm() {
-    guard isPerformingBatchUpdates == false else { return }
-    guard cache.state != .isRunning else { return }
+    guard isPerformingBatchUpdates == false,
+      !isDeallocating,
+      cache.state != .isRunning else { return }
 
     if cache.state == .empty {
       cache.state = .isRunning

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -34,6 +34,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   }
 
   deinit {
+    scrollView.isDeallocating = true
     children.forEach { $0.removeFromParent() }
     purgeRemovedViews()
 


### PR DESCRIPTION
Improves performance on all platforms by opting-out from doing any layout calcualtions when a `FamilyViewController` is being deallocated.