### PR TITLE
Add layout fix for macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.3"
+  s.version          = "0.14.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -70,6 +70,13 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     }
   }
 
+  open override func viewDidAppear() {
+    super.viewDidAppear()
+    // Make sure that we do another layout pass when the view controller appears.
+    // It helps ensure that we get the correct sizes on the subviews inside the `FamilyScrollView`.
+    NotificationCenter.default.post(Notification.init(name: NSWindow.didResizeNotification))
+  }
+
   open override func viewDidLayout() {
     super.viewDidLayout()
 


### PR DESCRIPTION
Adds a layout fix on macOS to ensure that the subviews get the correct sizes when the view controller appears, without the fix the views don't get the correct sizes until the window is resized.