### PR TITLE
Fix subviews issue on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.4"
+  s.version          = "0.14.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -70,13 +70,6 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     }
   }
 
-  open override func viewDidAppear() {
-    super.viewDidAppear()
-    // Make sure that we do another layout pass when the view controller appears.
-    // It helps ensure that we get the correct sizes on the subviews inside the `FamilyScrollView`.
-    NotificationCenter.default.post(Notification.init(name: NSWindow.didResizeNotification))
-  }
-
   open override func viewDidLayout() {
     super.viewDidLayout()
 

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -32,6 +32,9 @@ class FamilyWrapperView: NSScrollView {
 
     self.frameObserver = view.observe(\.frame, options: [.new, .old], changeHandler: { [weak self] (_, value) in
       guard abs(value.newValue?.size.height ?? 0) != abs(value.oldValue?.size.height ?? 0) else { return }
+      if let newValue = value.newValue {
+        self?.setWrapperFrameSize(newValue)
+      }
       self?.layoutViews(from: value.oldValue, to: value.newValue)
     })
 
@@ -69,6 +72,10 @@ class FamilyWrapperView: NSScrollView {
 
     isScrolling = !(event.deltaX == 0 && event.deltaY == 0) ||
       !(event.phase == .ended || event.momentumPhase == .ended)
+  }
+
+  private func setWrapperFrameSize(_ rect: CGRect) {
+    frame.size = rect.size
   }
 
   func layoutViews(from fromValue: CGRect? = nil, to toValue: CGRect? = nil) {


### PR DESCRIPTION
- Revert previous layout fix #97 
- Adds new `setWrapperFrameSize` in  `FamilyWrapperView`