### PR TITLE
Update FamilyClipView.swift

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.6"
+  s.version          = "0.14.7"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyClipView.swift
+++ b/Sources/macOS/Classes/FamilyClipView.swift
@@ -1,14 +1,13 @@
 import Cocoa
 
 class FamilyClipView: NSClipView {
+  var wrapperView: FamilyWrapperView? { return enclosingScrollView as? FamilyWrapperView }
+  var scrollView: FamilyScrollView? { return wrapperView?.enclosingScrollView as? FamilyScrollView }
 
   override func scroll(to newOrigin: NSPoint) {
     super.scroll(to: newOrigin)
-    guard let wrapperView = enclosingScrollView as? FamilyWrapperView,
-      let familyScrollView = wrapperView.enclosingScrollView as? FamilyScrollView else {
-        return
-    }
-
+    guard let wrapperView = wrapperView, let familyScrollView = scrollView else { return }
+    familyScrollView.isScrollingByProxy = true
     familyScrollView.scrollTo(newOrigin, in: documentView!)
   }
 }


### PR DESCRIPTION
Use `.isScrollingByProxy` on `FamilyClipView`.

Fixes rendering issues when views like `NSCollectionView` wants to scroll to a new position.