### PR TITLE
Refactor FamilyWrapperView to be more streamlined

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.7"
+  s.version          = "0.14.8"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyClipView.swift
+++ b/Sources/macOS/Classes/FamilyClipView.swift
@@ -6,7 +6,7 @@ class FamilyClipView: NSClipView {
 
   override func scroll(to newOrigin: NSPoint) {
     super.scroll(to: newOrigin)
-    guard let wrapperView = wrapperView, let familyScrollView = scrollView else { return }
+    guard let familyScrollView = scrollView else { return }
     familyScrollView.isScrollingByProxy = true
     familyScrollView.scrollTo(newOrigin, in: documentView!)
   }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -74,7 +74,7 @@ public class FamilyScrollView: NSScrollView {
       NSAnimationContext.beginGrouping()
       NSAnimationContext.current.duration = 0.0
       NSAnimationContext.current.allowsImplicitAnimation = false
-      defer { NSAnimationContext.endGrouping() }
+      NSAnimationContext.endGrouping()
     }
 
     layoutIsRunning = true
@@ -194,7 +194,6 @@ public class FamilyScrollView: NSScrollView {
       }
     }
 
-    guard window != nil else { return }
     cache.invalidate()
     layoutViews(withDuration: 0.0, force: false, completion: nil)
   }

--- a/Tests/macOS/FamilyContentViewTests.swift
+++ b/Tests/macOS/FamilyContentViewTests.swift
@@ -8,10 +8,12 @@ class FamilyContentViewTests: XCTestCase {
 
 
     override func layoutViews(withDuration duration: CFTimeInterval?,
+                              allowsImplicitAnimation: Bool,
                               force: Bool,
                               completion: (() -> Void)?) {
       super.layoutViews(
         withDuration: duration,
+        allowsImplicitAnimation: true,
         force: force,
         completion: nil
       )


### PR DESCRIPTION
- 💻 Unify observer behavior in `FamilyWrapperView`
- 💻 Optimize `FamilyScrollView` to avoid doing unnecessary rendering calls