### PR TITLE
Fix retain cycle in macOS implementation

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.9"
+  s.version          = "0.14.10"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -37,7 +37,6 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     scrollView.isDeallocating = true
     children.forEach { $0.removeFromParent() }
     purgeRemovedViews()
-
     if let eventHandlerKeyDown = eventHandlerKeyDown { NSEvent.removeMonitor(eventHandlerKeyDown) }
   }
 
@@ -64,8 +63,8 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
       scrollView.isScrollEnabled = false
       scrollView.frame = view.bounds
     }
-    eventHandlerKeyDown = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { (event) -> NSEvent? in
-      self.scrollView.isScrollingByProxy = true
+    eventHandlerKeyDown = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event -> NSEvent? in
+      self?.scrollView.isScrollingByProxy = true
       return event
     }
   }


### PR DESCRIPTION
`NSEvent.addLocalMonitorForEvents` holds a strong reference to the scroll view. Using settings the reference to self as weak resolves the retain cycle and fixes the memory leak.