### PR TITLE
Optimize layout algorithm with correct height

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.14"
+  s.version          = "0.14.15"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -302,7 +302,7 @@ public class FamilyScrollView: NSScrollView {
 
         let remainingBoundsHeight = fmax(documentVisibleRect.maxY - frame.minY, 0.0)
         let remainingContentHeight = fmax(contentSize.height - contentOffset.y, 0.0)
-        var newHeight: CGFloat = abs(fmin(documentVisibleRect.maxY, contentSize.height))
+        var newHeight: CGFloat = abs(fmin(documentVisibleRect.size.height, contentSize.height))
 
         if remainingBoundsHeight <= -self.frame.size.height {
           newHeight = 0
@@ -361,7 +361,7 @@ public class FamilyScrollView: NSScrollView {
 
       let remainingBoundsHeight = fmax(documentVisibleRect.maxY - frame.minY, 0.0)
       let remainingContentHeight = fmax(entry.contentSize.height - contentOffset.y, 0.0)
-      var newHeight: CGFloat = abs(fmin(documentVisibleRect.maxY, entry.contentSize.height))
+      var newHeight: CGFloat = abs(fmin(documentVisibleRect.size.height, entry.contentSize.height))
 
       if remainingBoundsHeight <= -self.frame.size.height {
         newHeight = 0


### PR DESCRIPTION
Instead of using `maxY` when setting the frame, we now use `size.height` which will
perform better with larger compositions.