### PR TITLE
Refactor validateScrollView on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.15"
+  s.version          = "0.14.16"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -262,10 +262,11 @@ public class FamilyScrollView: NSScrollView {
   private func validateScrollView(_ scrollView: NSScrollView) -> Bool {
     guard scrollView.documentView != nil else { return false }
 
-    // Exlucde empty collection views.
-    if let collectionView = scrollView.documentView as? NSCollectionView,
-      collectionView.dataSource?.collectionView(collectionView, numberOfItemsInSection: 0) == 0 {
-      return false
+    // Exclude empty collection views.
+    if let collectionView = scrollView.documentView as? NSCollectionView {
+      guard collectionView.numberOfSections > 0 else { return false }
+      guard collectionView.numberOfItems(inSection: 0) > 0 else { return false }
+      return true
     }
 
     return scrollView.documentView?.isHidden == false && (scrollView.documentView?.alphaValue ?? 1.0) > CGFloat(0.0)


### PR DESCRIPTION
Instead of resolving the data source, use the convenience methods on collection view to achieving the same result. In addition, check if there is a section, otherwise return early.