### PR TITLE
Improve performBatchUpdates on macOS

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.14.15"
+  s.version          = "0.14.16"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -230,7 +230,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     scrollView.isPerformingBatchUpdates = true
     handler(self)
     scrollView.isPerformingBatchUpdates = false
-    scrollView.layoutViews(withDuration: 0.25, force: false) {
+    scrollView.layoutViews(withDuration: NSAnimationContext.current.duration, force: false) {
       completion?(self)
     }
   }


### PR DESCRIPTION
- 💻 Instead of using a hardcoded value of 0.25 as duration for `performBatchUpdates`, it now uses `NSAnimationContext.current.duration` which can be set before invoking the method.