### PR TITLE
Don't invoke layout related methods in deinit

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.15.0"
+  s.version          = "0.15.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -84,6 +84,16 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     fatalError("init(coder:) has not been implemented")
   }
 
+  public override func setNeedsLayout() {
+    guard !isDeallocating else { return }
+    super.setNeedsLayout()
+  }
+
+  public override func layoutIfNeeded() {
+    guard !isDeallocating else { return }
+    super.layoutIfNeeded()
+  }
+
   /// Tells the view that its superview changed.
   open override func didMoveToSuperview() {
     super.didMoveToSuperview()


### PR DESCRIPTION
- 📱/ 📺 Avoids potential crashes when `FamilyViewController`'s are deallocated by not invoking any system layout calls from `deinit`.