### PR TITLE
Improve public API and space management

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.15.4"
+  s.version          = "0.16.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/FamilyFriendly.swift
+++ b/Sources/Shared/FamilyFriendly.swift
@@ -5,16 +5,16 @@ protocol FamilyFriendly: class {
   func addChild(_ childController: ViewController)
   func addChild<T: ViewController>(_ childController: T,
                                    at index: Int?,
-                                   customInsets: Insets?,
+                                   insets: Insets?,
                                    height: CGFloat?,
-                                   view handler: ((T) -> View)?)
-  func addChildren(_ childControllers: ViewController ...)
+                                   view handler: ((T) -> View)?) -> Self
+  func addChildren(_ childControllers: ViewController ...) -> Self
   func addView(_ subview: View,
                at index: Int?,
-               customInsets insets: Insets?,
-               withHeight height: CGFloat?)
-  func moveChild(_ childController: ViewController, to index: Int)
+               insets: Insets?,
+               height: CGFloat?) -> Self
+  func moveChild(_ childController: ViewController, to index: Int)  -> Self
   func performBatchUpdates(_ handler: (FamilyViewController) -> Void,
-                           completion: ((FamilyViewController) -> Void)?)
-  func purgeRemovedViews()
+                           completion: ((FamilyViewController) -> Void)?) -> Self
+  func purgeRemovedViews() -> Self
 }

--- a/Sources/Shared/FamilyViewControllerAttributes.swift
+++ b/Sources/Shared/FamilyViewControllerAttributes.swift
@@ -1,10 +1,10 @@
 import CoreGraphics
 
 public class FamilyViewControllerAttributes: NSObject {
-  let view: View
-  let origin: CGPoint
-  let contentSize: CGSize
-  let maxY: CGFloat
+  public let view: View
+  public let origin: CGPoint
+  public let contentSize: CGSize
+  public let maxY: CGFloat
 
   init(view: View, origin: CGPoint, contentSize: CGSize) {
     self.view = view

--- a/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
@@ -18,6 +18,15 @@ public class FamilyDocumentView: UIView {
     return subviews.compactMap { $0 as? UIScrollView }
   }
 
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+    autoresizesSubviews = false
+  }
+  
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
   /// Adds a view to the end of the receiver’s list of subviews.
   /// If view do not inherit from `UIScrollView`, the view will be
   /// wrapped in a `FamilyWrapperView` that works as a scroll view

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
@@ -21,7 +21,7 @@ extension FamilyScrollView {
         var contentOffset = scrollView.contentOffset
 
         if self.contentOffset.y < yOffsetOfCurrentSubview {
-          contentOffset.y = insets.top
+          contentOffset.y = 0
           frame.origin.y = round(yOffsetOfCurrentSubview)
         } else {
           contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
@@ -34,14 +34,17 @@ extension FamilyScrollView {
 
         if scrollView is FamilyWrapperView {
           newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+          frame.origin.y = yOffsetOfCurrentSubview
+          frame.origin.x = 0
+          frame.size.width = self.frame.size.width
+          frame.size.height = newHeight
         } else {
           newHeight = fmin(documentView.frame.height, newHeight)
+          frame.origin.y = yOffsetOfCurrentSubview
+          frame.origin.x = insets.left
+          frame.size.width = self.frame.size.width - insets.left - insets.right
+          frame.size.height = newHeight
         }
-
-        frame.origin.y = yOffsetOfCurrentSubview
-        frame.origin.x = insets.left
-        frame.size.width = self.frame.size.width - insets.left - insets.right
-        frame.size.height = newHeight
 
         if scrollView.frame != frame {
           scrollView.frame = frame

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
@@ -38,18 +38,23 @@ extension FamilyScrollView {
 
         if scrollView is FamilyWrapperView {
           newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
+          frame.origin.y = yOffsetOfCurrentSubview
+          frame.origin.x = 0
+          frame.size.width = self.frame.size.width
+          frame.size.height = newHeight
         } else {
           newHeight = fmin(documentView.frame.height, newHeight)
+          frame.origin.y = yOffsetOfCurrentSubview
+          frame.origin.x = insets.left
+          frame.size.width = self.frame.size.width - insets.left - insets.right
+          frame.size.height = newHeight
         }
 
         if newHeight == 0 {
           newHeight = fmin(documentView.frame.height, scrollView.contentSize.height)
         }
 
-        frame.origin.y = yOffsetOfCurrentSubview
-        frame.origin.x = insets.left
-        frame.size.width = self.frame.size.width - insets.left - insets.right
-        frame.size.height = newHeight
+
 
         if scrollView.frame != frame {
           scrollView.frame = frame

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -1,7 +1,6 @@
 import Cocoa
 
 open class FamilyViewController: NSViewController, FamilyFriendly {
-
   public lazy var baseView = NSView()
   public lazy var scrollView: FamilyScrollView = .init()
   /// The scroll view constraints.
@@ -102,11 +101,12 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   ///   - height: The height that the child controllers should be constrained to.
   ///   - handler: A closure used to resolve a view other than `.view` on controller used
   ///              to render the view controller.
+  @discardableResult
   public func addChild<T: ViewController>(_ childController: T,
                                           at index: Int? = nil,
-                                          customInsets insets: Insets? = nil,
+                                          insets: Insets? = nil,
                                           height: CGFloat? = nil,
-                                          view handler: ((T) -> View)? = nil) {
+                                          view handler: ((T) -> View)? = nil) -> Self {
     super.addChild(childController)
 
     let subview: View
@@ -121,25 +121,30 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
 
     scrollView.frame = view.bounds
     subview.frame.size.width = view.bounds.width
-    addView(subview, at: index, customInsets: insets, withHeight: height)
+    addView(subview, at: index, insets: insets, height: height)
     registry[childController] = subview
     scrollView.purgeWrapperViews()
+
+    return self
   }
 
   /// Adds a collection of view controllers as children of the current view controller.
   ///
   /// - Parameter childControllers: The view controllers to be added as children.
-  public func addChildren(_ childControllers: NSViewController ...) {
-    addChildren(childControllers)
+  @discardableResult
+  public func addChildren(_ childControllers: NSViewController ...) -> Self {
+    return addChildren(childControllers)
   }
 
   /// Adds a collection of view controllers as children of the current view controller.
   ///
   /// - Parameter childControllers: The view controllers to be added as children.
-  public func addChildren(_ childControllers: [NSViewController]) {
+  @discardableResult
+  public func addChildren(_ childControllers: [NSViewController]) -> Self {
     for childController in childControllers {
       addChild(childController)
     }
+    return self
   }
 
   /// Add a new view to hierarchy.
@@ -149,10 +154,11 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   ///   - index: The index that the view should appear.
   ///   - height: An optional height of the view.
   ///   - insets: The insets that should be applied to the view.
+  @discardableResult
   public func addView(_ subview: View,
                       at index: Int? = nil,
-                      customInsets insets: Insets? = nil,
-                      withHeight height: CGFloat? = nil) {
+                      insets: Insets? = nil,
+                      height: CGFloat? = nil) -> Self {
     if let height = height {
       subview.frame.size.width = view.bounds.size.width
       subview.frame.size.height = height
@@ -165,6 +171,8 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     if let insets = insets {
       setCustomInsets(insets, for: subview)
     }
+
+    return self
   }
 
   /// Move child view controller to index.
@@ -172,9 +180,11 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   /// - Parameters:
   ///   - childController: The child view controller that should be moved to index.
   ///   - index: The new index of the child view controller.
-  open func moveChild(_ childController: ViewController, to index: Int) {
-    guard let view = registry[childController] else { return }
+  @discardableResult
+  open func moveChild(_ childController: ViewController, to index: Int) -> Self {
+    guard let view = registry[childController] else { return self }
     addOrInsertView(view, at: index)
+    return self
   }
 
   /// Returns a collection of view controllers in layout order.
@@ -225,14 +235,16 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   ///   - handler: The operations that should be performed as a group.
   ///   - completion: A completion handler that is invoked after the view
   ///                 has laid out its views.
+  @discardableResult
   public func performBatchUpdates(_ handler: (FamilyViewController) -> Void,
-                                  completion: ((FamilyViewController) -> Void)?) {
+                                  completion: ((FamilyViewController) -> Void)?) -> Self {
     scrollView.isPerformingBatchUpdates = true
     handler(self)
     scrollView.isPerformingBatchUpdates = false
     scrollView.layoutViews(withDuration: NSAnimationContext.current.duration, force: false) {
       completion?(self)
     }
+    return self
   }
 
   /// Check if a view controller is visible on screen.
@@ -270,11 +282,13 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   }
 
   /// Remove stray views from view hierarchy.
-  func purgeRemovedViews() {
+  @discardableResult
+  func purgeRemovedViews() -> Self {
     for (controller, view) in registry where controller.parent == nil {
       view.enclosingScrollView?.removeFromSuperview()
       registry.removeValue(forKey: controller)
     }
+    return self
   }
 
   // MARK: - Private methods


### PR DESCRIPTION
- The public API labels are more unified
- The public API methods on `FamilyViewController` returns `Self` to make it easier to declare your UI
- Improves how spacing is handled
- Make `FamilyViewControllerAttributes` properties public
- Set `autoresizesSubviews` to `false`