### PR TITLE
Add support for sprint animation updates

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.16.0"
+  s.version          = "0.17.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ familyController.performBatchUpdates({ controller in
 })
 ```
 
+Adding animations
+
+When adding animations, not that you have to give them a key.
+```swift
+let basicAnimation = CABasicAnimation()
+basicAnimation.duration = 0.5
+controller.view.layer.add(springAnimation, forKey: "Basic Animations")
+
+let springAnimation = CASpringAnimation()
+springAnimation.damping = 0.6
+springAnimation.initialVelocity = 0.6
+springAnimation.mass = 0.4
+springAnimation.duration = 0.6
+springAnimation.isRemovedOnCompletion = false
+controller.view.layer.add(springAnimation, forKey: "Spring Animations")
+```
+
 
 ## Installation
 

--- a/Sources/iOS+tvOS/Extensions/CALayer+Extensions.swift
+++ b/Sources/iOS+tvOS/Extensions/CALayer+Extensions.swift
@@ -1,6 +1,26 @@
 import UIKit
 
 extension CALayer {
+  /// Returns all animations that have keys.
+  var allAnimationsWithKeys: [CAAnimation] {
+    var animations = [CAAnimation]()
+    guard let keys = animationKeys() else { return animations }
+    for key in keys {
+      if let animation = self.animation(forKey: key) {
+        animations.append(animation)
+      }
+    }
+    return animations
+  }
+
+  /// Resolve first animation matching type.
+  ///
+  /// - Parameter animationType: The type of CAAnimation that should be resolved.
+  /// - Returns: The first CAAnimation that matches the type.
+  func animation<T: CAAnimation>(_ animationType: T.Type) -> T? {
+    return allAnimationsWithKeys.compactMap({ $0 as? T }).first
+  }
+
   /// Resolve animation duration of the first animation using animation keys.
   var resolveAnimationDuration: CFTimeInterval? {
     if let firstKey = animationKeys()?.first,


### PR DESCRIPTION
By adding a `CASpringAnimation` to the view that updates, it is now possible to
animate the entire view hierarchy using a spring animation.
Determining which animation should be used is now more accurate as the animation
will be resolved inside the observer. This makes it more customizable as individual
components can use different types of animations when their layout attributes change.