### PR TITLE
Improve performance of runLayoutSubviews algorithm

### DIFF
--- a/Example/FamilyDemo/FamilyDemo.xcodeproj/project.pbxproj
+++ b/Example/FamilyDemo/FamilyDemo.xcodeproj/project.pbxproj
@@ -8,22 +8,26 @@
 
 /* Begin PBXBuildFile section */
 		9B3B6A2C9F23EE43005B57CA /* Pods_FamilyDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C86CBFC710F745C235E46A7 /* Pods_FamilyDemo.framework */; };
+		BD4515BA22FDA3EB00731DF6 /* CollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4515B922FDA3EB00731DF6 /* CollectionViewController.swift */; };
+		BD4515BC22FDA41900731DF6 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4515BB22FDA41900731DF6 /* Cell.swift */; };
 		D5C7F74E1C3BC9CE008CDDBA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D5C7F74C1C3BC9CE008CDDBA /* LaunchScreen.storyboard */; };
 		D5C7F75B1C3BCA1E008CDDBA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D5C7F7571C3BCA1E008CDDBA /* Assets.xcassets */; };
 		D5C7F75C1C3BCA1E008CDDBA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C7F7591C3BCA1E008CDDBA /* AppDelegate.swift */; };
-		D5C7F75D1C3BCA1E008CDDBA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C7F75A1C3BCA1E008CDDBA /* ViewController.swift */; };
+		D5C7F75D1C3BCA1E008CDDBA /* ContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C7F75A1C3BCA1E008CDDBA /* ContainerController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		0C86CBFC710F745C235E46A7 /* Pods_FamilyDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FamilyDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		20205134A50AAF695BC87348 /* Pods-FamilyDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FamilyDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo.release.xcconfig"; sourceTree = "<group>"; };
+		BD4515B922FDA3EB00731DF6 /* CollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewController.swift; sourceTree = "<group>"; };
+		BD4515BB22FDA41900731DF6 /* Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 		D1AFDB456D23A46ADFEA057E /* Pods-FamilyDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FamilyDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		D5C7F7401C3BC9CE008CDDBA /* FamilyDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FamilyDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C7F74D1C3BC9CE008CDDBA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D5C7F74F1C3BC9CE008CDDBA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5C7F7571C3BCA1E008CDDBA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D5C7F7591C3BCA1E008CDDBA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		D5C7F75A1C3BCA1E008CDDBA /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		D5C7F75A1C3BCA1E008CDDBA /* ContainerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +108,9 @@
 			isa = PBXGroup;
 			children = (
 				D5C7F7591C3BCA1E008CDDBA /* AppDelegate.swift */,
-				D5C7F75A1C3BCA1E008CDDBA /* ViewController.swift */,
+				D5C7F75A1C3BCA1E008CDDBA /* ContainerController.swift */,
+				BD4515B922FDA3EB00731DF6 /* CollectionViewController.swift */,
+				BD4515BB22FDA41900731DF6 /* Cell.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -121,7 +127,6 @@
 				D5C7F73D1C3BC9CE008CDDBA /* Frameworks */,
 				D5C7F73E1C3BC9CE008CDDBA /* Resources */,
 				C8D573C8F1F8DDAB63B3F691 /* [CP] Embed Pods Frameworks */,
-				7A8273B3F3BE95447E3022A6 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -153,6 +158,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -179,28 +185,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7A8273B3F3BE95447E3022A6 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		C8D573C8F1F8DDAB63B3F691 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Family/Family.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -209,7 +200,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FamilyDemo/Pods-FamilyDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DD9EC8FE4BB09ADD0F110FB8 /* [CP] Check Pods Manifest.lock */ = {
@@ -237,7 +228,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5C7F75D1C3BCA1E008CDDBA /* ViewController.swift in Sources */,
+				BD4515BA22FDA3EB00731DF6 /* CollectionViewController.swift in Sources */,
+				BD4515BC22FDA41900731DF6 /* Cell.swift in Sources */,
+				D5C7F75D1C3BCA1E008CDDBA /* ContainerController.swift in Sources */,
 				D5C7F75C1C3BCA1E008CDDBA /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -305,7 +298,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -351,7 +344,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -362,10 +355,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FamilyDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zenangst.FamilyDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -375,10 +369,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FamilyDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zenangst.FamilyDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/FamilyDemo/FamilyDemo.xcodeproj/xcshareddata/xcschemes/FamilyDemo.xcscheme
+++ b/Example/FamilyDemo/FamilyDemo.xcodeproj/xcshareddata/xcschemes/FamilyDemo.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -46,7 +45,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/FamilyDemo/FamilyDemo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/FamilyDemo/FamilyDemo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/FamilyDemo/FamilyDemo/Sources/AppDelegate.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/AppDelegate.swift
@@ -11,16 +11,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return controller
     }()
 
-  lazy var viewController: ViewController = {
-    let controller = ViewController()
-    return controller
-    }()
+  lazy var viewController: ContainerController = ContainerController()
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(loadApplication),
+      name: NSNotification.Name(rawValue: "INJECTION_BUNDLE_NOTIFICATION"),
+      object: nil
+    )
+    loadApplication()
+    return true
+  }
+
+  @objc func loadApplication() {
     window = UIWindow(frame: UIScreen.main.bounds)
     window?.rootViewController = navigationController
     window?.makeKeyAndVisible()
-
-    return true
   }
 }

--- a/Example/FamilyDemo/FamilyDemo/Sources/Cell.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/Cell.swift
@@ -1,9 +1,5 @@
-//
-//  Cell.swift
-//  FamilyDemo
-//
-//  Created by Christoffer Winterkvist on 8/9/19.
-//  Copyright © 2019 Hyper Interaktiv AS. All rights reserved.
-//
+import UIKit
 
-import Foundation
+class Cell: UICollectionViewCell {
+  
+}

--- a/Example/FamilyDemo/FamilyDemo/Sources/Cell.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/Cell.swift
@@ -1,0 +1,9 @@
+//
+//  Cell.swift
+//  FamilyDemo
+//
+//  Created by Christoffer Winterkvist on 8/9/19.
+//  Copyright © 2019 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Example/FamilyDemo/FamilyDemo/Sources/CollectionViewController.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/CollectionViewController.swift
@@ -1,9 +1,29 @@
-//
-//  CollectionViewController.swift
-//  FamilyDemo
-//
-//  Created by Christoffer Winterkvist on 8/9/19.
-//  Copyright © 2019 Hyper Interaktiv AS. All rights reserved.
-//
+import UIKit
 
-import Foundation
+class CollectionViewController: UICollectionViewController {
+  let numberOfItemsInSection: Int
+
+  init(numberOfItemsInSection: Int, layout: UICollectionViewLayout) {
+    self.numberOfItemsInSection = numberOfItemsInSection
+    super.init(collectionViewLayout: layout)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    collectionView.register(Cell.self, forCellWithReuseIdentifier: "Cell")
+  }
+
+  override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return numberOfItemsInSection
+  }
+
+  override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+    cell.contentView.backgroundColor = UIColor.black.withAlphaComponent(0.1)
+    return cell
+  }
+}

--- a/Example/FamilyDemo/FamilyDemo/Sources/CollectionViewController.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/CollectionViewController.swift
@@ -1,0 +1,9 @@
+//
+//  CollectionViewController.swift
+//  FamilyDemo
+//
+//  Created by Christoffer Winterkvist on 8/9/19.
+//  Copyright © 2019 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Example/FamilyDemo/FamilyDemo/Sources/ContainerController.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/ContainerController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Family
 
-class ViewController: UIViewController {
+class ContainerController: FamilViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Example/FamilyDemo/FamilyDemo/Sources/ContainerController.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/ContainerController.swift
@@ -1,11 +1,35 @@
 import UIKit
 import Family
 
-class ContainerController: FamilViewController {
+class ContainerController: FamilyViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = UIColor.white
+    title = "Loading"
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    performBatchUpdates(withDuration: 0.125, { _ in
+      for x in 0..<1000 {
+        let layout = UICollectionViewFlowLayout()
+        layout.sectionInset = .init(top: 10, left: 10, bottom: 0, right: 10)
+        layout.minimumLineSpacing = 10
+        layout.minimumInteritemSpacing = 10
+        layout.itemSize.height = 50
+
+        let viewController = CollectionViewController(numberOfItemsInSection: 12, layout: layout)
+        viewController.view.backgroundColor = .white
+        viewController.collectionView.backgroundColor = .white
+
+        add(viewController)
+        title = "Loaded \(x)"
+        CATransaction.flush()
+      }
+    }) { (_) in
+      self.title = "All done!"
+    }
   }
 }
 

--- a/Example/FamilyDemo/Podfile.lock
+++ b/Example/FamilyDemo/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Family (0.1.0)
+  - Family (0.18.8)
 
 DEPENDENCIES:
   - Family (from `../../`)
 
 EXTERNAL SOURCES:
   Family:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  Family: f3119f0ae4147f07b38152d9d4252506c1fd7767
+  Family: b5e2700968767ab72a699e84fc87d20cd9799035
 
 PODFILE CHECKSUM: ea1cf231165085455498ab2cfdabed6954efbee7
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.7.1

--- a/Family.xcodeproj/project.pbxproj
+++ b/Family.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		BD0FCCD720794AFB00D813EC /* FamilySpaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */; };
 		BD2236E32034B12A00C465E4 /* NSScrollView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */; };
 		BD44980E2034A09700ED83D4 /* FamilyWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */; };
+		BD4515BE22FDAC4500731DF6 /* BinarySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4515BD22FDAC4500731DF6 /* BinarySearch.swift */; };
+		BD4515BF22FDAC4500731DF6 /* BinarySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4515BD22FDAC4500731DF6 /* BinarySearch.swift */; };
+		BD4515C022FDAC4500731DF6 /* BinarySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4515BD22FDAC4500731DF6 /* BinarySearch.swift */; };
 		BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */; };
 		BD4C7FE020349AA10037D3E5 /* FamilyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */; };
 		BD4C7FE220349ACE0037D3E5 /* FamilyScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */; };
@@ -99,6 +102,7 @@
 		BD02F56821B43E7F006ECE48 /* FamilyViewControllerAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewControllerAttributes.swift; sourceTree = "<group>"; };
 		BD2236E22034B12A00C465E4 /* NSScrollView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScrollView+Extensions.swift"; sourceTree = "<group>"; };
 		BD44980D2034A09700ED83D4 /* FamilyWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyWrapperView.swift; sourceTree = "<group>"; };
+		BD4515BD22FDAC4500731DF6 /* BinarySearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinarySearch.swift; sourceTree = "<group>"; };
 		BD46A24F21B5D0E10042AD06 /* FamilyClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyClipView.swift; sourceTree = "<group>"; };
 		BD4C7FDF20349AA10037D3E5 /* FamilyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyViewController.swift; sourceTree = "<group>"; };
 		BD4C7FE120349ACE0037D3E5 /* FamilyScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyScrollView.swift; sourceTree = "<group>"; };
@@ -209,6 +213,7 @@
 				BD7629BD20349CA300C917BB /* FamilyFriendly.swift */,
 				BD535E152079269200AA2EC4 /* FamilySpaceManager.swift */,
 				BDAA8EE922D270ED00ECF0B1 /* BackgroundKind.swift */,
+				BD4515BD22FDAC4500731DF6 /* BinarySearch.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -638,6 +643,7 @@
 				BD5A80412030A9D9006A5EBB /* FamilyWrapperView.swift in Sources */,
 				BDAA8EEC22D2711100ECF0B1 /* BackgroundKind.swift in Sources */,
 				BD5A80432030A9D9006A5EBB /* FamilyScrollView.swift in Sources */,
+				BD4515C022FDAC4500731DF6 /* BinarySearch.swift in Sources */,
 				BD5A803F2030A9D9006A5EBB /* FamilyViewController.swift in Sources */,
 				BD7C17B522CD57BC001D3615 /* UIViewController+Extensions.swift in Sources */,
 				BDAC586F21B9916E00412766 /* FamilyCache.swift in Sources */,
@@ -681,6 +687,7 @@
 				BD92595E22A5388900E584A5 /* FamilyScrollView+tvOS.swift in Sources */,
 				BD7629BE20349CA300C917BB /* FamilyFriendly.swift in Sources */,
 				BDAC587021B9916E00412766 /* FamilyViewControllerAttributes.swift in Sources */,
+				BD4515BE22FDAC4500731DF6 /* BinarySearch.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -705,6 +712,7 @@
 				BDAA8EEE22D271C800ECF0B1 /* NSViewController+Extensions.swift in Sources */,
 				BDAA8EEB22D2711100ECF0B1 /* BackgroundKind.swift in Sources */,
 				BD44980E2034A09700ED83D4 /* FamilyWrapperView.swift in Sources */,
+				BD4515BF22FDAC4500731DF6 /* BinarySearch.swift in Sources */,
 				BD7629BF20349CA300C917BB /* FamilyFriendly.swift in Sources */,
 				BD4C7FE420349B030037D3E5 /* FamilyDocumentView.swift in Sources */,
 				BD46A25021B5D0E10042AD06 /* FamilyClipView.swift in Sources */,

--- a/Sources/Shared/BinarySearch.swift
+++ b/Sources/Shared/BinarySearch.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public class BinarySearch {
+  public init() {}
+
+  private func binarySearch(_ collection: [FamilyViewControllerAttributes],
+                            less: (FamilyViewControllerAttributes) -> Bool,
+                            match: (FamilyViewControllerAttributes) -> Bool) -> Int? {
+    guard var upperBound = collection.indices.last else { return nil }
+    upperBound += 1
+    var lowerBound = 0
+
+
+    while lowerBound < upperBound {
+      let midIndex = lowerBound + (upperBound - lowerBound) / 2
+      let element = collection[midIndex]
+
+      if match(element) {
+        return midIndex
+      } else if less(element) {
+        lowerBound = midIndex + 1
+      } else {
+        upperBound = midIndex
+      }
+    }
+
+    return nil
+  }
+
+  public func findElement(in collection: [FamilyViewControllerAttributes],
+                          upper: (FamilyViewControllerAttributes) -> Bool,
+                          lower: (FamilyViewControllerAttributes) -> Bool,
+                          less: (FamilyViewControllerAttributes) -> Bool,
+                          match: (FamilyViewControllerAttributes) -> Bool) -> FamilyViewControllerAttributes? {
+    guard let firstMatchIndex = binarySearch(collection,
+                                             less: less,
+                                             match: match) else {
+                                              return nil
+    }
+    return collection[firstMatchIndex]
+  }
+
+  public func findElements(in collection: [FamilyViewControllerAttributes],
+                           upper: (FamilyViewControllerAttributes) -> Bool,
+                           lower: (FamilyViewControllerAttributes) -> Bool,
+                           less: (FamilyViewControllerAttributes) -> Bool,
+                           match: (FamilyViewControllerAttributes) -> Bool) -> [FamilyViewControllerAttributes] {
+    guard let firstMatchIndex = binarySearch(collection,
+                                             less: less,
+                                             match: match) else {
+                                              return []
+    }
+
+    var results = [FamilyViewControllerAttributes]()
+    for element in collection[..<firstMatchIndex].reversed() {
+      guard upper(element) else { break }
+      results.append(element)
+    }
+
+    for element in collection[firstMatchIndex...] {
+      guard lower(element) else { break }
+      results.append(element)
+    }
+
+    return results
+  }
+}

--- a/Sources/Shared/FamilyCache.swift
+++ b/Sources/Shared/FamilyCache.swift
@@ -8,10 +8,13 @@ class FamilyCache: NSObject {
   var state: State = .empty
   var contentSize: CGSize = .zero
   var storage = [View: FamilyViewControllerAttributes]()
+  var collection = [FamilyViewControllerAttributes]()
   override init() {}
 
   func add(entry: FamilyViewControllerAttributes) {
     storage[entry.view] = entry
+    collection.append(entry)
+    collection.sort(by: { $0.frame.maxY < $1.frame.maxY })
   }
 
   func entry(for view: View) -> FamilyViewControllerAttributes? {
@@ -20,6 +23,7 @@ class FamilyCache: NSObject {
 
   func invalidate() {
     storage.removeAll()
+    collection.removeAll()
     state = .empty
   }
 }

--- a/Sources/Shared/FamilyViewControllerAttributes.swift
+++ b/Sources/Shared/FamilyViewControllerAttributes.swift
@@ -5,11 +5,21 @@ public class FamilyViewControllerAttributes: NSObject {
   public let origin: CGPoint
   public let contentSize: CGSize
   public let maxY: CGFloat
+  public var frame: CGRect {
+    return CGRect(origin: origin, size: contentSize)
+  }
+  public let scrollView: ScrollView
 
   init(view: View, origin: CGPoint, contentSize: CGSize) {
     self.view = view
     self.origin = origin
     self.contentSize = contentSize
     self.maxY = contentSize.height + origin.y
+    #if os(macOS)
+    self.scrollView = view.enclosingScrollView!
+    #else
+    self.scrollView = (view as? ScrollView) ?? view.superview as! ScrollView
+    #endif
+
   }
 }

--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -1,11 +1,13 @@
 #if os(macOS)
   import Cocoa
   public typealias ViewController = NSViewController
+  public typealias ScrollView = NSScrollView
   public typealias View = NSView
   public typealias Insets = NSEdgeInsets
 #else
   import UIKit
   public typealias ViewController = UIViewController
+  public typealias ScrollView = UIScrollView
   public typealias View = UIView
   public typealias Insets = UIEdgeInsets
 #endif

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
@@ -78,14 +78,15 @@ extension FamilyScrollView {
       contentSize = CGSize(width: cache.contentSize.width, height: height)
     }
 
-    for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
-      let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
-      let padding = spaceManager.padding(for: view)
+    for attributes in validAttributes() where attributes.scrollView.isHidden == false  {
+      let view = attributes.view
+      let scrollView = attributes.scrollView
       guard let entry = cache.entry(for: view) else { continue }
       if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
         continue
       }
 
+      let padding = spaceManager.padding(for: view)
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
@@ -86,14 +86,15 @@ extension FamilyScrollView {
       contentSize = CGSize(width: cache.contentSize.width, height: height)
     }
 
-    for scrollView in subviewsInLayoutOrder where scrollView.isHidden == false {
-      let view = (scrollView as? FamilyWrapperView)?.view ?? scrollView
-      let padding = spaceManager.padding(for: view)
+    for attributes in validAttributes() where attributes.scrollView.isHidden == false  {
+      let view = attributes.view
+      let scrollView = attributes.scrollView
       guard let entry = cache.entry(for: view) else { continue }
       if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
         continue
       }
 
+      let padding = spaceManager.padding(for: view)
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -460,6 +460,21 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
   }
 
+  func validAttributes() -> [FamilyViewControllerAttributes] {
+    let binarySearch = BinarySearch()
+    let rect = CGRect(origin: self.contentOffset, size: bounds.size)
+    let upper: (FamilyViewControllerAttributes) -> Bool = { attributes in attributes.frame.maxY >= rect.minY }
+    let lower: (FamilyViewControllerAttributes) -> Bool = { attributes in attributes.frame.minY <= rect.maxY }
+    let less: (FamilyViewControllerAttributes) -> Bool =  { attributes in attributes.frame.maxY <= rect.minY }
+    let attributes = cache.collection
+    let validAttributes = binarySearch.findElements(in: attributes,
+                                                    upper: upper,
+                                                    lower: lower,
+                                                    less: less,
+                                                    match: { $0.frame.intersects(rect) })
+    return validAttributes
+  }
+
   internal func compare(_ lhs: CGSize, to rhs: CGSize) -> Bool {
     return (abs(lhs.height - rhs.height) <= 0.001)
   }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -222,9 +222,9 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       childController.view.isHidden = true
       subview = handler(childController)
     } else {
-      subview = childController.view
-      childController.view.translatesAutoresizingMaskIntoConstraints = true
-      childController.view.autoresizingMask = [.flexibleWidth]
+      subview = viewToAdd(from: childController)
+      subview.translatesAutoresizingMaskIntoConstraints = true
+      subview.autoresizingMask = [.flexibleWidth]
     }
 
     addView(subview, at: index, insets: insets, height: height)

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -379,11 +379,11 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   ///
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is visible on screen
-  public func viewControllerIsVisible(_ viewController: UIViewController) -> Bool {
-    guard let entry = registry[viewController] else { return false }
-    let view = wrappedViewIfNeeded(entry.view)
-    if view.frame.size.height == 0 { return false }
-    return view.frame.intersects(documentVisibleRect)
+  public func viewControllerIsVisible(_ viewController: ViewController) -> Bool {
+    guard let attributes = scrollView.validAttributes().first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+      return false
+    }
+    return attributes.scrollView.frame.intersects(documentVisibleRect)
   }
 
   /// Check if a view controller is fully visible on screen.
@@ -391,10 +391,10 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is fully visible on screen
   public func viewControllerIsFullyVisible(_ viewController: UIViewController) -> Bool {
-    guard let entry = registry[viewController] else { return false }
-    let view = wrappedViewIfNeeded(entry.view)
-    if view.frame.size.height == 0 { return false }
-    let convertedFrame = scrollView.documentView.convert(view.frame,
+    guard let attributes = scrollView.validAttributes().first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+      return false
+    }
+    let convertedFrame = scrollView.documentView.convert(attributes.scrollView.frame,
                                                          to: scrollView.documentView)
     return documentVisibleRect.contains(convertedFrame)
   }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -344,6 +344,8 @@ public class FamilyScrollView: NSScrollView {
         viewFrame.size.width = scrollView.isHorizontal ? contentSize.width : constrainedWidth
         viewFrame.size.height = contentSize.height
         view.frame = viewFrame
+
+        scrollView.frame.size = frame.size
         
         let entry: FamilyViewControllerAttributes = FamilyViewControllerAttributes(view: view,
                                                                                    origin: CGPoint(x: frame.origin.x,
@@ -372,7 +374,7 @@ public class FamilyScrollView: NSScrollView {
       let view = attributes.view
       let padding = spaceManager.padding(for: view)
       let margins = spaceManager.margins(for: view)
-      let currentXOffset = scrollView.isHorizontal ? scrollView.contentOffset.x : 0
+      let currentXOffset = scrollView.isHorizontal ? scrollView.contentOffset.x : margins.left
 
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
@@ -408,6 +410,7 @@ public class FamilyScrollView: NSScrollView {
         newHeight += padding.top + padding.bottom
       }
 
+      frame.origin.x = currentXOffset
       frame.size.height = newHeight
 
       // Only scroll if the views content offset is less than its content size height

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -370,10 +370,10 @@ public class FamilyScrollView: NSScrollView {
     for attributes in validAttributes() where validateScrollView(attributes.scrollView) {
       let scrollView = attributes.scrollView
       let view = attributes.view
-      guard let entry: FamilyViewControllerAttributes = cache.entry(for: view) else { continue }
       let padding = spaceManager.padding(for: view)
       let margins = spaceManager.margins(for: view)
       let currentXOffset = scrollView.isHorizontal ? scrollView.contentOffset.x : 0
+
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
 
@@ -383,17 +383,17 @@ public class FamilyScrollView: NSScrollView {
       scrollViewContentOffset.y = min(documentVisibleRect.origin.y + contentInsets.top,
                                       cache.contentSize.height - documentVisibleRect.size.height + contentInsets.top)
 
-      if self.contentOffset.y < entry.origin.y {
+      if self.contentOffset.y < attributes.origin.y {
         contentOffset.y = 0
-        frame.origin.y = abs(entry.origin.y)
+        frame.origin.y = abs(attributes.origin.y)
       } else {
-        contentOffset.y = abs(scrollViewContentOffset.y - entry.origin.y)
+        contentOffset.y = abs(scrollViewContentOffset.y - attributes.origin.y)
         frame.origin.y = abs(scrollViewContentOffset.y)
       }
 
       let remainingBoundsHeight = abs(fmax(documentVisibleRect.maxY - frame.minY, 0.0))
-      let remainingContentHeight = abs(fmax(entry.contentSize.height - contentOffset.y, 0.0))
-      var newHeight: CGFloat = abs(fmin(documentVisibleRect.size.height, entry.contentSize.height))
+      let remainingContentHeight = abs(fmax(attributes.contentSize.height - contentOffset.y, 0.0))
+      var newHeight: CGFloat = abs(fmin(documentVisibleRect.size.height, attributes.contentSize.height))
 
       if remainingBoundsHeight <= -self.frame.size.height {
         newHeight = 0
@@ -412,13 +412,13 @@ public class FamilyScrollView: NSScrollView {
 
       // Only scroll if the views content offset is less than its content size height
       // and if the frame is less than the content size height.
-      let shouldScroll = round(contentOffset.y) <= round(entry.contentSize.height) &&
-        round(frame.size.height) < round(entry.contentSize.height)
+      let shouldScroll = round(contentOffset.y) <= round(attributes.contentSize.height) &&
+        round(frame.size.height) < round(attributes.contentSize.height)
 
-      if !(entry.view is NSCollectionView) {
+      if !(attributes.view is NSCollectionView) {
         scrollView.contentOffset = CGPoint(x: 0, y: 0)
-        if frame.origin.y != abs(round(entry.origin.y)) {
-          frame.origin.y = abs(round(entry.origin.y))
+        if frame.origin.y != abs(round(attributes.origin.y)) {
+          frame.origin.y = abs(round(attributes.origin.y))
         }
       } else if shouldScroll {
         if scrollView.contentOffset.y != contentOffset.y {
@@ -426,11 +426,11 @@ public class FamilyScrollView: NSScrollView {
         }
       } else {
         if (abs(frame.origin.y - frame.origin.y) <= 0.001) {
-          frame.origin.y = entry.origin.y
+          frame.origin.y = attributes.origin.y
         }
         // Reset content offset to avoid setting offsets that
         // look like `clipsToBounds` bugs.
-        if self.contentOffset.y < entry.maxY && scrollView.contentOffset.y != 0 {
+        if self.contentOffset.y < attributes.maxY && scrollView.contentOffset.y != 0 {
           scrollView.contentOffset = CGPoint(x: currentXOffset, y: 0)
         }
       }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -340,23 +340,23 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   ///
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is visible on screen
-  public func viewControllerIsVisible(_ viewController: NSViewController) -> Bool {
-    guard let entry = registry[viewController] else { return false }
-    let view = wrappedViewIfNeeded(entry)
-    if view.frame.size.height == 0 { return false }
-    return view.frame.intersects(documentVisibleRect)
+  public func viewControllerIsVisible(_ viewController: ViewController) -> Bool {
+    guard let attributes = scrollView.validAttributes().first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+      return false
+    }
+    return attributes.scrollView.frame.intersects(documentVisibleRect)
   }
 
   /// Check if a view controller is fully visible on screen.
   ///
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is fully visible on screen
-  public func viewControllerIsFullyVisible(_ viewController: NSViewController) -> Bool {
-    guard let entry = registry[viewController] else { return false }
-    let view = wrappedViewIfNeeded(entry)
-    if view.frame.size.height == 0 { return false }
-    let convertedFrame = scrollView.familyDocumentView.convert(view.frame,
-                                                         to: scrollView.documentView)
+  public func viewControllerIsFullyVisible(_ viewController: ViewController) -> Bool {
+    guard let attributes = scrollView.validAttributes().first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+      return false
+    }
+    let convertedFrame = scrollView.familyDocumentView.convert(attributes.scrollView.frame,
+                                                               to: scrollView.documentView)
     return documentVisibleRect.contains(convertedFrame)
   }
 

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -87,7 +87,7 @@ class FamilyWrapperView: NSScrollView {
     let oldValue = frame
     let newValue = rect
 
-    frame.size = newValue.size
+    frame.size.height = newValue.size.height
     familyScrollView?.wrapperViewDidChangeFrame(view, from: oldValue, to: newValue)
     guard view is NSCollectionView else { return }
     NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(delayedUpdate), object: nil)

--- a/Tests/macOS/FamilyViewControllerTests.swift
+++ b/Tests/macOS/FamilyViewControllerTests.swift
@@ -134,7 +134,7 @@ class FamilyViewControllerTests: XCTestCase {
     }
 
     familyViewController.addChildren([
-      controller1, controller2, controller3
+      controller1, controller2, controller3, controller4
       ])
 
     XCTAssertTrue(familyViewController.viewControllerIsVisible(controller1))

--- a/Tests/macOS/FamilyViewControllerTests.swift
+++ b/Tests/macOS/FamilyViewControllerTests.swift
@@ -129,7 +129,7 @@ class FamilyViewControllerTests: XCTestCase {
     let controller3 = MockViewController()
     let controller4 = MockViewController()
 
-    [controller1, controller2, controller3].forEach {
+    [controller1, controller2, controller3, controller4].forEach {
       $0.view.frame.size = CGSize(width: 375, height: 667)
     }
 
@@ -146,6 +146,9 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertFalse(familyViewController.viewControllerIsVisible(controller3))
     XCTAssertFalse(familyViewController.viewControllerIsFullyVisible(controller3))
 
+    XCTAssertFalse(familyViewController.viewControllerIsVisible(controller4))
+    XCTAssertFalse(familyViewController.viewControllerIsFullyVisible(controller4))
+
     familyViewController.scrollView.contentOffset = .init(x: 0, y: 667 / 2)
 
     XCTAssertTrue(familyViewController.viewControllerIsVisible(controller1))
@@ -156,6 +159,9 @@ class FamilyViewControllerTests: XCTestCase {
 
     XCTAssertFalse(familyViewController.viewControllerIsVisible(controller3))
     XCTAssertFalse(familyViewController.viewControllerIsFullyVisible(controller3))
+
+    XCTAssertFalse(familyViewController.viewControllerIsVisible(controller4))
+    XCTAssertFalse(familyViewController.viewControllerIsFullyVisible(controller4))
 
     familyViewController.scrollView.contentOffset = .init(x: 0, y: 667)
 


### PR DESCRIPTION
This PR refactors the core layout algorithm for iOS, tvOS and macOS by implementing `binary search` for which views are valid for modification when running the `runLayoutSubviews` method in `FamilyScrollView`.