### PR TITLE
Improve lookup performance by using attributes

### DIFF
--- a/Sources/Shared/FamilySpaceManager.swift
+++ b/Sources/Shared/FamilySpaceManager.swift
@@ -20,6 +20,16 @@ class FamilySpaceManager {
     return margins[targetView] ?? defaultMargins
   }
 
+  /// Get margins for the attributes, if the view does not have custom insets
+  /// then the general spacing will be returned.
+  ///
+  /// - Parameter attributes: The attributes for a view controller.
+  /// - Returns: The amount of insets that should appear after the view, either
+  ///            custom insets or the general insets.
+  func margins(for attributes: FamilyViewControllerAttributes) -> Insets {
+    return margins[attributes.view] ?? defaultMargins
+  }
+
   /// Get padding for the view, if the view does not have custom insets
   /// then the general spacing will be returned.
   ///
@@ -29,6 +39,16 @@ class FamilySpaceManager {
   func padding(for view: View) -> Insets {
     let targetView = (view as? FamilyWrapperView)?.view ?? view
     return padding[targetView] ?? defaultPadding
+  }
+
+  /// Get padding for the attributes, if the view does not have custom insets
+  /// then the general spacing will be returned.
+  ///
+  /// - Parameter attributes: The attributes for a view controller.
+  /// - Returns: The amount of insets that should appear after the view, either
+  ///            custom insets or the general insets.
+  func padding(for attributes: FamilyViewControllerAttributes) -> Insets {
+    return padding[attributes.view] ?? defaultPadding
   }
 
   /// Set margins for view.

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
@@ -78,28 +78,22 @@ extension FamilyScrollView {
       contentSize = CGSize(width: cache.contentSize.width, height: height)
     }
 
-    for attributes in validAttributes() where attributes.scrollView.isHidden == false  {
-      let view = attributes.view
+    for attributes in validAttributes() where attributes.view.isHidden == false  {
       let scrollView = attributes.scrollView
-      guard let entry = cache.entry(for: view) else { continue }
-      if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
-        continue
-      }
-
-      let padding = spaceManager.padding(for: view)
+      let padding = spaceManager.padding(for: attributes)
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
 
-      if self.contentOffset.y < entry.origin.y {
+      if self.contentOffset.y < attributes.origin.y {
         contentOffset.y = 0.0
-        frame.origin.y = abs(round(entry.origin.y))
+        frame.origin.y = abs(round(attributes.origin.y))
       } else {
-        contentOffset.y = self.contentOffset.y - entry.origin.y
+        contentOffset.y = self.contentOffset.y - attributes.origin.y
         frame.origin.y = abs(round(self.contentOffset.y))
       }
 
-      let remainingBoundsHeight = bounds.maxY - entry.origin.y
-      let remainingContentHeight = entry.contentSize.height - contentOffset.y
+      let remainingBoundsHeight = bounds.maxY - attributes.origin.y
+      let remainingContentHeight = attributes.contentSize.height - contentOffset.y
       var newHeight: CGFloat = fmin(documentView.frame.height, scrollView.contentSize.height)
 
       if remainingBoundsHeight <= -self.frame.size.height {
@@ -115,23 +109,23 @@ extension FamilyScrollView {
       }
 
       let shouldScroll = (round(self.contentOffset.y) >= round(frame.origin.y) &&
-        round(self.contentOffset.y) < round(entry.maxY)) &&
+        round(self.contentOffset.y) < round(attributes.maxY)) &&
         round(frame.height) >= round(documentView.frame.height)
 
       if scrollView is FamilyWrapperView {
-        if self.contentOffset.y < entry.origin.y {
+        if self.contentOffset.y < attributes.origin.y {
           scrollView.contentOffset.y = contentOffset.y
         } else {
-          frame.origin.y = entry.origin.y
+          frame.origin.y = attributes.origin.y
         }
       } else if shouldScroll {
         scrollView.contentOffset.y = contentOffset.y
       } else {
-        frame.origin.y = entry.origin.y
+        frame.origin.y = attributes.origin.y
 
         // Reset content offset to avoid setting offsets that
         // look liked `clipsToBounds` bugs.
-        if self.contentOffset.y < entry.maxY && scrollView.contentOffset.y != 0 {
+        if self.contentOffset.y < attributes.maxY && scrollView.contentOffset.y != 0 {
           scrollView.contentOffset.y = 0
         }
       }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
@@ -86,28 +86,22 @@ extension FamilyScrollView {
       contentSize = CGSize(width: cache.contentSize.width, height: height)
     }
 
-    for attributes in validAttributes() where attributes.scrollView.isHidden == false  {
-      let view = attributes.view
+    for attributes in validAttributes() where attributes.view.isHidden == false  {
       let scrollView = attributes.scrollView
-      guard let entry = cache.entry(for: view) else { continue }
-      if (scrollView as? FamilyWrapperView)?.view.isHidden == true {
-        continue
-      }
-
-      let padding = spaceManager.padding(for: view)
+      let padding = spaceManager.padding(for: attributes)
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
 
-      if self.contentOffset.y < entry.origin.y {
+      if self.contentOffset.y < attributes.origin.y {
         contentOffset.y = 0.0
-        frame.origin.y = round(entry.origin.y)
+        frame.origin.y = round(attributes.origin.y)
       } else {
-        contentOffset.y = self.contentOffset.y - entry.origin.y
+        contentOffset.y = self.contentOffset.y - attributes.origin.y
         frame.origin.y = round(self.contentOffset.y)
       }
 
-      let remainingBoundsHeight = bounds.maxY - entry.origin.y
-      let remainingContentHeight = entry.contentSize.height - contentOffset.y
+      let remainingBoundsHeight = bounds.maxY - attributes.origin.y
+      let remainingContentHeight = attributes.contentSize.height - contentOffset.y
       var newHeight: CGFloat = fmin(documentView.frame.height, scrollView.contentSize.height)
 
       if remainingBoundsHeight <= -self.frame.size.height {
@@ -123,22 +117,22 @@ extension FamilyScrollView {
       }
 
       let shouldScroll = (round(self.contentOffset.y) >= round(frame.origin.y) &&
-        round(self.contentOffset.y) < round(entry.maxY)) &&
+        round(self.contentOffset.y) < round(attributes.maxY)) &&
         round(frame.height) >= round(documentView.frame.height)
 
       if scrollView is FamilyWrapperView {
-        if self.contentOffset.y < entry.origin.y {
+        if self.contentOffset.y < attributes.origin.y {
           scrollView.contentOffset.y = contentOffset.y
         } else {
-          frame.origin.y = entry.origin.y
+          frame.origin.y = attributes.origin.y
         }
       } else if shouldScroll {
         scrollView.contentOffset.y = contentOffset.y
       } else {
-        frame.origin.y = entry.origin.y
+        frame.origin.y = attributes.origin.y
         // Reset content offset to avoid setting offsets that
         // look liked `clipsToBounds` bugs.
-        if self.contentOffset.y < entry.maxY {
+        if self.contentOffset.y < attributes.maxY {
           scrollView.contentOffset.y = 0
         }
       }


### PR DESCRIPTION
This PR optimizes the previous improvements to the render method by using the attribute variable for looking up padding and margins. It essentially removes redundant type-casting in methods that need to be lightning fast.