### PR TITLE
Improve use of binary search on tvOS

### DIFF
--- a/Example/FamilyDemo/FamilyDemo/Info.plist
+++ b/Example/FamilyDemo/FamilyDemo/Info.plist
@@ -31,6 +31,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/Example/FamilyDemo/FamilyDemo/Sources/ContainerController.swift
+++ b/Example/FamilyDemo/FamilyDemo/Sources/ContainerController.swift
@@ -11,17 +11,20 @@ class ContainerController: FamilyViewController {
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    performBatchUpdates(withDuration: 0.125, { _ in
-      for x in 0..<1000 {
+    performBatchUpdates(withDuration: 0, { _ in
+      for x in 0..<75 {
         let layout = UICollectionViewFlowLayout()
-        layout.sectionInset = .init(top: 10, left: 10, bottom: 0, right: 10)
+        layout.sectionInset = .init(top: 10, left: 10, bottom: 10, right: 10)
         layout.minimumLineSpacing = 10
         layout.minimumInteritemSpacing = 10
         layout.itemSize.height = 50
 
-        let viewController = CollectionViewController(numberOfItemsInSection: 12, layout: layout)
-        viewController.view.backgroundColor = .white
-        viewController.collectionView.backgroundColor = .white
+        let viewController = CollectionViewController(numberOfItemsInSection: 12 * 2, layout: layout)
+        let background = x % 2 == 0
+          ? UIColor.white
+          : UIColor.lightGray.withAlphaComponent(0.5)
+        viewController.view.backgroundColor = background
+        viewController.collectionView.backgroundColor = background
 
         add(viewController)
         title = "Loaded \(x)"

--- a/Example/FamilyDemo/Podfile.lock
+++ b/Example/FamilyDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Family (0.18.8)
+  - Family (0.19.0)
 
 DEPENDENCIES:
   - Family (from `../../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Family: b5e2700968767ab72a699e84fc87d20cd9799035
+  Family: 3c2602269c9f6a4134f2619b401e4fe036c35f88
 
 PODFILE CHECKSUM: ea1cf231165085455498ab2cfdabed6954efbee7
 
-COCOAPODS: 1.7.1
+COCOAPODS: 1.7.5

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
@@ -78,7 +78,8 @@ extension FamilyScrollView {
       contentSize = CGSize(width: cache.contentSize.width, height: height)
     }
 
-    for attributes in validAttributes() where attributes.view.isHidden == false  {
+    let rect = CGRect(origin: self.contentOffset, size: bounds.size)
+    for attributes in validAttributes(in: rect) where attributes.view.isHidden == false  {
       let scrollView = attributes.scrollView
       let padding = spaceManager.padding(for: attributes)
       var frame = scrollView.frame

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
@@ -86,7 +86,9 @@ extension FamilyScrollView {
       contentSize = CGSize(width: cache.contentSize.width, height: height)
     }
 
-    for attributes in validAttributes() where attributes.view.isHidden == false  {
+    let rect = CGRect(origin: CGPoint(x: self.contentOffset.x, y: max(self.contentOffset.y - bounds.size.height / 2, 0)),
+                      size: CGSize(width: bounds.size.width, height: bounds.size.height + bounds.size.height / 2))
+    for attributes in validAttributes(in: rect) where attributes.view.isHidden == false  {
       let scrollView = attributes.scrollView
       let padding = spaceManager.padding(for: attributes)
       var frame = scrollView.frame

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -460,12 +460,20 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
   }
 
-  func validAttributes() -> [FamilyViewControllerAttributes] {
+  func validAttributes(in rect: CGRect) -> [FamilyViewControllerAttributes] {
     let binarySearch = BinarySearch()
-    let rect = CGRect(origin: self.contentOffset, size: bounds.size)
-    let upper: (FamilyViewControllerAttributes) -> Bool = { attributes in attributes.frame.maxY >= rect.minY }
-    let lower: (FamilyViewControllerAttributes) -> Bool = { attributes in attributes.frame.minY <= rect.maxY }
-    let less: (FamilyViewControllerAttributes) -> Bool =  { attributes in attributes.frame.maxY <= rect.minY }
+    let upper: (FamilyViewControllerAttributes) -> Bool = { attributes in
+      attributes.frame.maxY >= rect.minY ||
+      attributes.scrollView.frame.maxY >= rect.minY
+    }
+    let lower: (FamilyViewControllerAttributes) -> Bool = { attributes in
+      attributes.frame.minY <= rect.maxY ||
+      attributes.scrollView.frame.minY <= rect.maxY
+    }
+    let less: (FamilyViewControllerAttributes) -> Bool =  { attributes in
+      attributes.frame.maxY < rect.minY ||
+      attributes.scrollView.frame.maxY < rect.minY
+    }
     let attributes = cache.collection
     let validAttributes = binarySearch.findElements(in: attributes,
                                                     upper: upper,

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -380,7 +380,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is visible on screen
   public func viewControllerIsVisible(_ viewController: ViewController) -> Bool {
-    guard let attributes = scrollView.validAttributes().first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+    guard let attributes = scrollView.validAttributes(in: scrollView.documentVisibleRect)
+      .first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
       return false
     }
     return attributes.scrollView.frame.intersects(documentVisibleRect)
@@ -391,7 +392,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is fully visible on screen
   public func viewControllerIsFullyVisible(_ viewController: UIViewController) -> Bool {
-    guard let attributes = scrollView.validAttributes().first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+    guard let attributes = scrollView.validAttributes(in: scrollView.documentVisibleRect)
+      .first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
       return false
     }
     let convertedFrame = scrollView.documentView.convert(attributes.scrollView.frame,


### PR DESCRIPTION
This PR adjusts how binary search is used on iOS and tvOS.
It is primarily a fix to make the new algorithm play better with tvOS as it needs to know about items that are slightly off-screen to inform the focus engine what comes next. 