### PR TITLE
Don't include equal when comparing shouldScroll

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.19.1"
+  s.version          = "0.19.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+iOS.swift
@@ -122,7 +122,7 @@ extension FamilyScrollView {
 
       let shouldScroll = (round(self.contentOffset.y) >= round(frame.origin.y) &&
         round(self.contentOffset.y) < round(attributes.maxY)) &&
-        round(frame.height) >= round(documentView.frame.height)
+        round(frame.height) > round(documentView.frame.height)
 
       if scrollView is FamilyWrapperView {
         if scrollView.contentOffset.y != contentOffset.y && self.contentOffset.y < scrollView.frame.origin.y {

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView+tvOS.swift
@@ -126,7 +126,7 @@ extension FamilyScrollView {
 
       let shouldScroll = (round(self.contentOffset.y) >= round(frame.origin.y) &&
         round(self.contentOffset.y) < round(attributes.maxY)) &&
-        round(frame.height) >= round(documentView.frame.height)
+        round(frame.height) > round(documentView.frame.height)
 
       if scrollView is FamilyWrapperView {
         if scrollView.contentOffset.y != contentOffset.y && self.contentOffset.y < scrollView.frame.origin.y {


### PR DESCRIPTION
Fixes the `shouldScroll` condition by excluding views that are exactly the same size as the document view.