### PR TITLE
Performance improvements on macOS by using Instruments

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.20.3"
+  s.version          = "0.20.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -94,7 +94,7 @@ class FamilyWrapperView: NSScrollView {
                                   force: true,
                                   completion: nil)
     guard needsDisplay else { return }
-    familyScrollView?.needsDisplay = true
+    familyScrollView?.setNeedsDisplay(frame)
     familyScrollView?.layoutSubtreeIfNeeded()
   }
 

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -88,6 +88,7 @@ class FamilyWrapperView: NSScrollView {
   }
 
   private func invalidateFamilyScrollView(needsDisplay: Bool) {
+    guard familyScrollView?.isPerformingBatchUpdates == false else { return }
     familyScrollView?.cache.invalidate()
     familyScrollView?.layoutViews(withDuration: nil,
                                   allowsImplicitAnimation: false,

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -79,14 +79,6 @@ class FamilyWrapperView: NSScrollView {
       !(event.phase == .ended || event.momentumPhase == .ended)
   }
 
-  override func viewWillMove(toWindow newWindow: NSWindow?) {
-    super.viewWillMove(toWindow: newWindow)
-
-    if newWindow == nil {
-      invalidateFamilyScrollView(needsDisplay: true)
-    }
-  }
-
   private func invalidateFamilyScrollView(needsDisplay: Bool) {
     guard familyScrollView?.isPerformingBatchUpdates == false else { return }
     familyScrollView?.cache.invalidate()


### PR DESCRIPTION
- Stop invalidating the `FamilyScrollView` when the window is set to `nil`
- Add checks for not doing extra work when the `FamilyScrollView` is performing batch updates
- Only invalidate the current rectangle when `FamilyWrapperView` wants to invalidate the `FamilyScrollView`.