### PR TITLE
Set default duration to 0.0 in body method

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.20.4"
+  s.version          = "0.20.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -196,6 +196,7 @@ public class FamilyScrollView: NSScrollView {
     backgrounds[view] = backgroundView
     familyDocumentView.addSubview(backgroundView, positioned: .below, relativeTo: view)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews(withDuration: nil, force: false, completion: nil)
   }
 
@@ -210,6 +211,7 @@ public class FamilyScrollView: NSScrollView {
     }
 
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews(withDuration: 0.0, force: false, completion: nil)
   }
 
@@ -225,6 +227,7 @@ public class FamilyScrollView: NSScrollView {
   public func addPadding(_ insets: Insets, for view: View) {
     spaceManager.addPadding(insets, for: view)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews(withDuration: nil, force: false, completion: nil)
   }
 
@@ -235,6 +238,7 @@ public class FamilyScrollView: NSScrollView {
   public func addMargins(_ insets: Insets, for view: View) {
     spaceManager.addMargins(insets, for: view)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews(withDuration: nil, force: false, completion: nil)
   }
 

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -79,7 +79,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
 
   // MARK: - Public methods
 
-  public func body(withDuration duration: Double = 0.25,
+  public func body(withDuration duration: Double = 0.0,
                    _ closure: () -> Void) {
     performBatchUpdates(withDuration: duration, { _ in
       closure()

--- a/Tests/Shared/FamilyViewControllerSharedTests.swift
+++ b/Tests/Shared/FamilyViewControllerSharedTests.swift
@@ -43,9 +43,8 @@ class FamilyViewControllerSharedTests: XCTestCase {
 
 
     #if os(macOS)
-    XCTAssertEqual(childViewController.view.frame, CGRect(origin: .init(x: 0, y: 0),
+    XCTAssertEqual(childViewController.view.frame, CGRect(origin: .init(x: 10, y: 10),
                                                           size: CGSize(width: 460, height: 500)))
-
     XCTAssertEqual(childViewController.view.enclosingScrollView?.contentInsets.top, padding.top)
     XCTAssertEqual(childViewController.view.enclosingScrollView?.contentInsets.left, padding.left)
     XCTAssertEqual(childViewController.view.enclosingScrollView?.contentInsets.right, padding.right)


### PR DESCRIPTION
- 💫 Changes the default `duration` of the `body` method to be `0.0` as it fits better with macOS