### PR TITLE
Improve internal performance

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.20.5"
+  s.version          = "0.20.6"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -191,6 +191,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     addSubview(backgroundView)
     sendSubviewToBack(backgroundView)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews()
   }
 
@@ -247,6 +248,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
     spaceManager.removeView(subview)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutIfNeeded()
   }
 
@@ -377,6 +379,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   public func addPadding(_ insets: Insets, for view: View) {
     spaceManager.addPadding(insets, for: view)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews()
   }
 
@@ -387,6 +390,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   public func addMargins(_ insets: Insets, for view: View) {
     spaceManager.addMargins(insets, for: view)
     cache.invalidate()
+    guard !isPerformingBatchUpdates else { return }
     layoutViews()
   }
 
@@ -415,6 +419,8 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   public func layoutViews(withDuration duration: Double? = nil,
                           animation: CAAnimation? = nil,
                           completion: (() -> Void)? = nil) {
+    guard !isPerformingBatchUpdates else { return }
+
     defer {
       // Clean up invalid views.
       if !isScrolling {
@@ -423,8 +429,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         }
       }
     }
-
-    guard isPerformingBatchUpdates == false else { return }
 
     guard !isDeallocating else { return }
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -373,6 +373,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     scrollView.isPerformingBatchUpdates = true
     handler(self)
     scrollView.isPerformingBatchUpdates = false
+    scrollView.cache.invalidate()
     scrollView.layoutViews(withDuration: duration, animation: animation) {
       completion?(self)
     }


### PR DESCRIPTION
- 💂‍♀️ Apply perform batch updates guards to iOS and tvOS to reduce the amount of redrawing
- 💎 Always invalidate cache after performing batch updates on iOS and tvOS
- 🧼 Add cleanup method for discardable views to macOS implementation