### PR TITLE
Optimize layout algorithm to avoid sub pixel rendering and other improvements

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.20.6"
+  s.version          = "0.20.7"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/FamilyViewControllerAttributes.swift
+++ b/Sources/Shared/FamilyViewControllerAttributes.swift
@@ -14,7 +14,7 @@ public class FamilyViewControllerAttributes: NSObject {
     self.view = view
     self.origin = origin
     self.contentSize = contentSize
-    self.maxY = contentSize.height + origin.y
+    self.maxY = round(contentSize.height + origin.y)
     #if os(macOS)
     self.scrollView = view.enclosingScrollView!
     #else

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -596,7 +596,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
           contentOffset.y = 0.0
           frame.origin.y = round(yOffsetOfCurrentSubview)
         } else {
-          contentOffset.y = parentContentOffset.y - yOffsetOfCurrentSubview
+          contentOffset.y = round(parentContentOffset.y - yOffsetOfCurrentSubview)
           frame.origin.y = parentContentOffset.y
         }
 
@@ -614,7 +614,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
         frame.size.width = self.frame.size.width - margins.left - margins.right
         frame.size.height = round(newHeight)
-        frame.origin.y = yOffsetOfCurrentSubview
+        frame.origin.y = round(yOffsetOfCurrentSubview)
 
         if !frame.intersects(documentVisibleRect) {
           frame.size.height = 0
@@ -624,16 +624,16 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
         cache.add(entry: FamilyViewControllerAttributes(view: view,
                                                         origin: CGPoint(x: frame.origin.x,
-                                                                        y: yOffsetOfCurrentSubview + padding.top),
+                                                                        y: round(yOffsetOfCurrentSubview + padding.top)),
                                                         contentSize: scrollView.contentSize))
 
         if let backgroundView = backgrounds[view] {
-          frame.origin.y = yOffsetOfCurrentSubview
+          frame.origin.y = round(yOffsetOfCurrentSubview)
           positionBackgroundView(scrollView, frame, margins, padding, backgroundView, view)
         }
 
         if scrollView.contentSize.height > 0 {
-          yOffsetOfCurrentSubview += scrollView.contentSize.height + margins.bottom + padding.top + padding.bottom
+          yOffsetOfCurrentSubview += round(scrollView.contentSize.height + margins.bottom + padding.top + padding.bottom)
         }
       }
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -371,9 +371,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   /// directly, call `setNeedsLayout()` instead.
   open override func layoutSubviews() {
     super.layoutSubviews()
-    defer { previousContentOffset = contentOffset }
-    let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer.animationKeys() != nil }) != nil
-    guard contentOffset != previousContentOffset || cache.state == .empty || shouldLayoutViews else { return }
     layoutViews()
   }
 
@@ -425,6 +422,10 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
                           animation: CAAnimation? = nil,
                           completion: (() -> Void)? = nil) {
     guard !isPerformingBatchUpdates else { return }
+
+    defer { previousContentOffset = contentOffset }
+    let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer.animationKeys() != nil }) != nil
+    guard contentOffset != previousContentOffset || cache.state == .empty || shouldLayoutViews else { return }
 
     defer {
       // Clean up invalid views.

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestureRecognizerDelegate {
-  private var previousContentOffset: CGPoint = .zero
+  private var previousContentOffset: CGPoint = .init(x: -1, y: -1)
 
   /// The amount of insets that should be inserted inbetween views.
   public var margins: Insets {

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -568,6 +568,8 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   internal func runLayoutSubviewsAlgorithm() {
     guard cache.state != .isRunning else { return }
 
+    let parentContentOffset = CGPoint(x: round(self.contentOffset.x), y: round(self.contentOffset.y))
+
     if cache.state == .empty {
       cache.state = .isRunning
       var yOffsetOfCurrentSubview: CGFloat = 0.0
@@ -585,12 +587,12 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         var frame = scrollView.frame
         var contentOffset = scrollView.contentOffset
 
-        if self.contentOffset.y < yOffsetOfCurrentSubview {
+        if parentContentOffset.y < yOffsetOfCurrentSubview {
           contentOffset.y = 0.0
           frame.origin.y = round(yOffsetOfCurrentSubview)
         } else {
-          contentOffset.y = self.contentOffset.y - yOffsetOfCurrentSubview
-          frame.origin.y = round(self.contentOffset.y)
+          contentOffset.y = parentContentOffset.y - yOffsetOfCurrentSubview
+          frame.origin.y = parentContentOffset.y
         }
 
         let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
@@ -606,7 +608,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         }
 
         frame.size.width = self.frame.size.width - margins.left - margins.right
-        frame.size.height = newHeight
+        frame.size.height = round(newHeight)
         frame.origin.y = yOffsetOfCurrentSubview
 
         if !frame.intersects(documentVisibleRect) {
@@ -630,10 +632,10 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         }
       }
 
-      let computedHeight = yOffsetOfCurrentSubview
+      let computedHeight = round(yOffsetOfCurrentSubview)
       let minimumContentHeight = bounds.height - (contentInset.top + contentInset.bottom)
       var height = fmax(computedHeight, minimumContentHeight)
-      cache.contentSize = CGSize(width: bounds.size.width, height: yOffsetOfCurrentSubview)
+      cache.contentSize = CGSize(width: bounds.size.width, height: computedHeight)
 
       if isChildViewController {
         height = computedHeight
@@ -641,7 +643,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       }
 
       cache.state = .isFinished
-      contentSize = CGSize(width: cache.contentSize.width, height: height)
+      contentSize = CGSize(width: cache.contentSize.width, height: round(height))
     }
 
     let validAttributes = getValidAttributes(in: discardableRect)
@@ -651,12 +653,12 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       var frame = scrollView.frame
       var contentOffset = scrollView.contentOffset
 
-      if self.contentOffset.y < scrollView.frame.origin.y {
+      if parentContentOffset.y < scrollView.frame.origin.y {
         contentOffset.y = 0.0
         frame.origin.y = round(scrollView.frame.origin.y)
       } else {
-        contentOffset.y = self.contentOffset.y - scrollView.frame.origin.y
-        frame.origin.y = round(self.contentOffset.y)
+        contentOffset.y = round(parentContentOffset.y - scrollView.frame.origin.y)
+        frame.origin.y = parentContentOffset.y
       }
 
       var newHeight: CGFloat = fmin(documentView.frame.height, scrollView.contentSize.height)
@@ -670,12 +672,12 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         newHeight += padding.top + padding.bottom
       }
 
-      let shouldScroll = (round(self.contentOffset.y) >= round(frame.origin.y) &&
-        round(self.contentOffset.y) < round(attributes.maxY)) &&
+      let shouldScroll = (parentContentOffset.y >= round(frame.origin.y) &&
+        parentContentOffset.y < attributes.maxY) &&
         round(frame.height) > round(documentView.frame.height)
 
       if scrollView is FamilyWrapperView {
-        if scrollView.contentOffset.y != contentOffset.y && self.contentOffset.y < scrollView.frame.origin.y {
+        if scrollView.contentOffset.y != contentOffset.y && parentContentOffset.y < scrollView.frame.origin.y {
           scrollView.contentOffset.y = contentOffset.y
         } else {
           frame.origin.y = attributes.frame.origin.y
@@ -691,7 +693,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
         }
       }
 
-      frame.size.height = newHeight
+      frame.size.height = round(newHeight)
 
       if scrollView.frame != frame {
         scrollView.frame = frame

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -573,7 +573,8 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   internal func runLayoutSubviewsAlgorithm() {
     guard cache.state != .isRunning else { return }
 
-    let parentContentOffset = CGPoint(x: round(self.contentOffset.x), y: round(self.contentOffset.y))
+    let parentContentOffset = CGPoint(x: round(self.contentOffset.x),
+                                      y: round(self.contentOffset.y))
 
     if cache.state == .empty {
       cache.state = .isRunning

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -373,7 +373,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     super.layoutSubviews()
     defer { previousContentOffset = contentOffset }
     let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer.animationKeys() != nil }) != nil
-    guard contentOffset != previousContentOffset || shouldLayoutViews else { return }
+    guard contentOffset != previousContentOffset || cache.state == .empty || shouldLayoutViews else { return }
     layoutViews()
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestureRecognizerDelegate {
+  private var previousContentOffset: CGPoint = .zero
+
   /// The amount of insets that should be inserted inbetween views.
   public var margins: Insets {
     get { return spaceManager.defaultMargins }
@@ -369,6 +371,9 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   /// directly, call `setNeedsLayout()` instead.
   open override func layoutSubviews() {
     super.layoutSubviews()
+    defer { previousContentOffset = contentOffset }
+    let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer.animationKeys() != nil }) != nil
+    guard contentOffset != previousContentOffset || shouldLayoutViews else { return }
     layoutViews()
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -339,7 +339,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
       if strongSelf.scrollViewIsHorizontal(scrollView), abs(newValue.y) != 0 {
         scrollView.contentOffset.y = 0
-        strongSelf.runLayoutSubviewsAlgorithm()
+        strongSelf.layoutViews()
       }
     })
     observers.append(Observer(view: view, keyValueObservation: contentOffsetObserver))

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -1,6 +1,7 @@
 import Cocoa
 
 public class FamilyScrollView: NSScrollView {
+  private var previousContentOffset: CGPoint = .init(x: -1, y: -1)
   public override var isFlipped: Bool { return true }
 
   public var margins: Insets {
@@ -86,7 +87,14 @@ public class FamilyScrollView: NSScrollView {
                           allowsImplicitAnimation: Bool = true,
                           force: Bool,
                           completion: (() -> Void)?) {
+
     guard isPerformingBatchUpdates == false, !isDeallocating else { return }
+
+    let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer?.animationKeys() != nil }) != nil
+    guard contentOffset != previousContentOffset || cache.state == .empty || shouldLayoutViews else {
+      return
+    }
+    defer { previousContentOffset = contentOffset }
 
     defer {
       // Clean up invalid views.
@@ -286,6 +294,7 @@ public class FamilyScrollView: NSScrollView {
     isScrolling = !(event.deltaX == 0 && event.deltaY == 0) ||
       !(event.phase == .ended || event.momentumPhase == .ended)
     isScrollingWithWheel = isScrolling
+
     layoutViews(withDuration: 0.0, force: false, completion: nil)
   }
 

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -87,7 +87,6 @@ public class FamilyScrollView: NSScrollView {
                           allowsImplicitAnimation: Bool = true,
                           force: Bool,
                           completion: (() -> Void)?) {
-
     guard isPerformingBatchUpdates == false, !isDeallocating else { return }
 
     let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer?.animationKeys() != nil }) != nil

--- a/Tests/tvOS/FamilyScrollViewTests.swift
+++ b/Tests/tvOS/FamilyScrollViewTests.swift
@@ -98,7 +98,7 @@ class FamilyScrollViewTests: XCTestCase {
 
     // Check that layout algorithm takes spacing between views into account.
     scrollView.margins = .init(top: 0, left: 0, bottom: 10, right: 0)
-    scrollView.layoutSubviews()
+    scrollView.layoutViews()
 
     XCTAssertEqual(mockedScrollView1.frame, CGRect(origin: .zero, size: size))
     XCTAssertEqual(mockedScrollView2.frame, CGRect(origin: CGPoint(x: 0, y: 250 + scrollView.margins.bottom), size: size))


### PR DESCRIPTION
This PR improves the overall performance of the framework

- Values are now rounded to avoid sub-pixel rendering which can lead to performance penalties
- `layoutSubviews` on `FamilyScrollView` do not call `layoutViews` more than it has too