### PR TITLE
Various internal improvements

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.20.10"
+  s.version          = "0.20.11"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.20.11"
+  s.version          = "0.21.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyDocumentView.swift
@@ -21,6 +21,7 @@ public class FamilyDocumentView: UIView {
   public override init(frame: CGRect) {
     super.init(frame: frame)
     autoresizesSubviews = false
+    clipsToBounds = true
   }
   
   required init?(coder aDecoder: NSCoder) {

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -8,7 +8,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     get { return spaceManager.defaultMargins }
     set {
       spaceManager.defaultMargins = newValue
-      cache.invalidate()
+      invalidateLayout()
     }
   }
 
@@ -16,7 +16,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     get { return spaceManager.defaultPadding }
     set {
       spaceManager.defaultPadding = newValue
-      cache.invalidate()
+      invalidateLayout()
     }
   }
 
@@ -25,7 +25,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   public override var bounds: CGRect {
     willSet {
       if newValue.width != bounds.width {
-        cache.invalidate()
+        invalidateLayout()
       }
     }
   }
@@ -99,7 +99,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   override public var frame: CGRect {
     willSet {
       if newValue.width != frame.width {
-        cache.invalidate()
+        invalidateLayout()
       }
     }
   }
@@ -169,7 +169,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     backgrounds[view] = backgroundView
     addSubview(backgroundView)
     sendSubviewToBack(backgroundView)
-    cache.invalidate()
+    invalidateLayout()
     guard !isPerformingBatchUpdates else { return }
     layoutViews()
   }
@@ -195,7 +195,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       configureScrollView(scrollView)
     }
 
-    cache.invalidate()
+    invalidateLayout()
     setNeedsLayout()
     layoutIfNeeded()
   }
@@ -226,7 +226,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     }
 
     spaceManager.removeView(subview)
-    cache.invalidate()
+    invalidateLayout()
     guard !isPerformingBatchUpdates else { return }
     layoutIfNeeded()
   }
@@ -286,7 +286,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
       if self?.compare(newValue, to: oldValue) == false {
         let contentOffset = strongSelf.contentOffset
-        strongSelf.cache.invalidate()
+        strongSelf.invalidateLayout()
         let targetView = (scrollView as? FamilyWrapperView)?.view ?? scrollView
         let animation = targetView.layer.allAnimationsWithKeys.first
         strongSelf.layoutViews(animation: animation)
@@ -305,7 +305,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       if newValue != oldValue {
         let targetView = (scrollView as? FamilyWrapperView)?.view ?? scrollView
         let animation = targetView.layer.allAnimationsWithKeys.first
-        self?.cache.invalidate()
+        self?.invalidateLayout()
         self?.layoutViews(animation: animation)
       }
     })
@@ -359,7 +359,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
   public func addPadding(_ insets: Insets, for view: View) {
     spaceManager.addPadding(insets, for: view)
-    cache.invalidate()
+    invalidateLayout()
     guard !isPerformingBatchUpdates else { return }
     layoutViews()
   }
@@ -370,9 +370,14 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
 
   public func addMargins(_ insets: Insets, for view: View) {
     spaceManager.addMargins(insets, for: view)
-    cache.invalidate()
+    invalidateLayout()
     guard !isPerformingBatchUpdates else { return }
     layoutViews()
+  }
+
+  func invalidateLayout() {
+    cache.invalidate()
+    self.previousContentOffset = nil
   }
 
   /// Remove wrapper views that don't own their underlaying views.
@@ -555,7 +560,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   }
 
   @objc func injected() {
-    cache.invalidate()
+    invalidateLayout()
     layoutViews()
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -49,30 +49,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     return rect
   }
 
-  lazy var visibleRectLayer: UIView = {
-    let view = UIView()
-    view.isUserInteractionEnabled = false
-    view.layer.borderColor = UIColor.green.cgColor
-    view.layer.borderWidth = 2
-    return view
-  }()
-
-  lazy var validRectLayer: UIView = {
-    let view = UIView()
-    view.isUserInteractionEnabled = false
-    view.layer.borderColor = UIColor.yellow.cgColor
-    view.layer.borderWidth = 2
-    return view
-  }()
-
-  lazy var discardRectLayer: UIView = {
-    let view = UIView()
-    view.isUserInteractionEnabled = false
-    view.layer.borderColor = UIColor.red.cgColor
-    view.layer.borderWidth = 2
-    return view
-  }()
-
   /// The current viewport
   public var documentVisibleRect: CGRect {
     return CGRect(origin: contentOffset,
@@ -152,9 +128,6 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       contentInsetAdjustmentBehavior = .never
     }
     addSubview(documentView)
-    addSubview(discardRectLayer)
-    addSubview(validRectLayer)
-    addSubview(visibleRectLayer)
   }
 
   required public init?(coder aDecoder: NSCoder) {
@@ -495,10 +468,9 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     rect.origin.y = max(contentOffset.y - (offset / 2), 0)
     rect.size.height = bounds.size.height + offset
     // Clean up invalid views.
-    let discardableScrollViews = subviewsInLayoutOrder.filter { $0.frame.size.height != 0 && !$0.frame.intersects(discardableRect) }
-
-    for (offset, scrollView) in discardableScrollViews.enumerated() {
-      Swift.print(scrollView)
+    let discardableScrollViews = subviewsInLayoutOrder
+      .filter { $0.frame.size.height != 0 && !$0.frame.intersects(discardableRect) }
+    for scrollView in discardableScrollViews {
       scrollView.frame.size.height = 0
     }
   }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -354,6 +354,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   }
 
   public func addPadding(_ insets: Insets, for view: View) {
+    guard insets != spaceManager.padding(for: view) else { return }
     spaceManager.addPadding(insets, for: view)
     invalidateLayout()
     guard !isPerformingBatchUpdates else { return }
@@ -365,6 +366,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
   }
 
   public func addMargins(_ insets: Insets, for view: View) {
+    guard insets != spaceManager.margins(for: view) else { return }
     spaceManager.addMargins(insets, for: view)
     invalidateLayout()
     guard !isPerformingBatchUpdates else { return }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -312,7 +312,9 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
     observers.append(Observer(view: view, keyValueObservation: hiddenObserver))
 
     let contentOffsetObserver = view.observe(\.contentOffset, options: [.new], changeHandler: { [weak self] (scrollView, value) in
-      guard let strongSelf = self, let newValue = value.newValue else {
+      guard let strongSelf = self,
+        let newValue = value.newValue,
+        let oldValue = value.oldValue else {
         return
       }
 

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -433,7 +433,7 @@ public class FamilyScrollView: UIScrollView, FamilyDocumentViewDelegate, UIGestu
       documentView.bounds = CGRect(origin: contentOffset, size: bounds.size)
     }
 
-    let options: UIView.AnimationOptions = [.allowUserInteraction, .beginFromCurrentState]
+    let options: UIView.AnimationOptions = [.allowUserInteraction, .beginFromCurrentState, .preferredFramesPerSecond60]
     let animations = { self.runLayoutSubviewsAlgorithm() }
     let animationCompletion: (Bool) -> Void = { _ in completion?() }
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -373,7 +373,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     scrollView.isPerformingBatchUpdates = true
     handler(self)
     scrollView.isPerformingBatchUpdates = false
-    scrollView.cache.invalidate()
     scrollView.layoutViews(withDuration: duration, animation: animation) {
       completion?(self)
     }


### PR DESCRIPTION
- 🏎 Improves the rendering method by skipping unnecessary layout passes on 📱📺
- 🛠 Improves the content offset observer by opting out if both values aren't set 📱📺
- 💂🏻‍♀️ Add guard for setting same insets when adding padding and margins 📱📺
- 💫 Remove explicit invalidation of layout when performing batch updates 📱📺
- 🍒 The document view will now clip to bounds to avoid offscreen rendering 📱📺
- 🧹 Remove previous debug implementation 📱📺