### PR TITLE
Improve macOS features

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.22.3"
+  s.version          = "0.22.4"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyClipView.swift
+++ b/Sources/macOS/Classes/FamilyClipView.swift
@@ -7,7 +7,7 @@ class FamilyClipView: NSClipView {
 
   override func scroll(to newOrigin: NSPoint) {
     super.scroll(to: newOrigin)
-    guard let familyScrollView = scrollView else { return }
+    guard let familyScrollView = scrollView, newOrigin.y != contentInsets.top else { return }
     familyScrollView.isScrollingByProxy = true
     familyScrollView.scrollTo(newOrigin, in: documentView!)
   }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -378,14 +378,13 @@ public class FamilyScrollView: NSScrollView {
         let padding = spaceManager.padding(for: view)
         let margins = spaceManager.margins(for: view)
         let constrainedWidth = round(self.frame.size.width) - margins.left - margins.right - padding.left - padding.right
-        let currentXOffset = scrollView.isHorizontal ? scrollView.contentOffset.x : margins.left
         var frame = scrollView.frame
         var viewFrame = frame
 
         yOffsetOfCurrentSubview += round(margins.top)
 
         frame.origin.y = round(yOffsetOfCurrentSubview)
-        frame.origin.x = currentXOffset
+        frame.origin.x = margins.left
         frame.size.height = round(min(visibleRect.height, contentSize.height))
         frame.size.width = round(self.frame.size.width) - margins.left - margins.right
 
@@ -393,12 +392,13 @@ public class FamilyScrollView: NSScrollView {
           frame.size.height = 0
         }
 
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = padding
+
         if view is NSCollectionView {
           viewFrame.origin.x = padding.left
           viewFrame.origin.y = padding.top
         } else {
-          scrollView.automaticallyAdjustsContentInsets = false
-          scrollView.contentInsets = padding
           frame.size.height += padding.top + padding.bottom
         }
 
@@ -435,7 +435,6 @@ public class FamilyScrollView: NSScrollView {
         }
 
         cache.state = .isRunning
-
         let previousContentOffset = self.contentOffset
         self.contentOffset = previousContentOffset
       }
@@ -505,7 +504,9 @@ public class FamilyScrollView: NSScrollView {
         }
         // Reset content offset to avoid setting offsets that
         // look like `clipsToBounds` bugs.
-        if self.contentOffset.y < attributes.maxY && scrollView.contentOffset.y != 0 {
+        if self.contentOffset.y < attributes.maxY &&
+          scrollView.contentOffset.y != 0 &&
+          !scrollView.isHorizontal {
           scrollView.contentOffset = CGPoint(x: currentXOffset, y: 0)
         }
       }

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -39,7 +39,7 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
     if let eventHandlerKeyDown = eventHandlerKeyDown { NSEvent.removeMonitor(eventHandlerKeyDown) }
   }
 
-  // MARK: - View lifecycle
+  // MARK: - View life cycle
 
   open override func loadView() {
     let view = baseView
@@ -176,6 +176,8 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
       view.addSubview(childController.view)
       childController.view.frame.size = .zero
       subview = handler(childController)
+    } else if let scrollView = childController.view as? ScrollView {
+      subview = scrollView.documentView ?? scrollView
     } else {
       subview = childController.view
     }


### PR DESCRIPTION
- 🌸 Improves the `addChild` method when adding a child view controller that uses a scroll view as a view. It will now use the scroll views document view which plays better with the framework. It removes the need for using the `view` closure for those cases on macOS
- 💎 Improves the use of padding and margins when using collection views on macOS