### PR TITLE
Remove previous content offset optimization

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.22.4"
+  s.version          = "0.22.5"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -1,8 +1,6 @@
 import UIKit
 
 public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
-  private var previousContentOffset: CGPoint?
-
   var scrollViews: [UIScrollView] {
     return subviews.compactMap { $0 as? UIScrollView }
   }
@@ -445,7 +443,6 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
 
   func invalidateLayout() {
     cache.invalidate()
-    self.previousContentOffset = nil
   }
 
   /// Remove wrapper views that don't own their underlaying views.
@@ -480,15 +477,6 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
       return
     }
 
-    // Skip extra rendering pass.
-    #if os(tvOS)
-    if let previousContentOffset = previousContentOffset, duration == nil {
-      if previousContentOffset == contentOffset {
-        return
-      }
-    }
-    #endif
-
     if !isScrolling {
       purgeOffscreenViews(using: contentOffset)
     }
@@ -501,7 +489,6 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
     let animations = { self.runLayoutSubviewsAlgorithm() }
     let animationCompletion: (Bool) -> Void = { _ in
       completion?()
-      self.previousContentOffset = nil
     }
 
     if #available(iOS 9.0, *) {
@@ -520,14 +507,12 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
     }
 
     if let duration = duration, duration > 0.0 {
-      self.previousContentOffset = self.contentOffset
       UIView.animate(withDuration: duration, delay: 0.0,
                      options: options,
                      animations: runLayoutSubviewsAlgorithm,
                      completion: animationCompletion)
     } else {
       runLayoutSubviewsAlgorithm()
-      self.previousContentOffset = self.contentOffset
     }
   }
 


### PR DESCRIPTION
- Skipping rendering passes can result in rendering glitches on tvOS, this implementation is now removed