### PR TITLE
Feature FamilyScrollViewDelegate

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.22.7"
+  s.version          = "0.22.8"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -1,6 +1,11 @@
 import Cocoa
 
+public protocol FamilyScrollViewDelegate: class {
+  func familyScrollView(_ scrollView: FamilyScrollView, didScrollToPoint point: CGPoint, isScrolling: Bool)
+}
+
 public class FamilyScrollView: NSScrollView {
+  public weak var delegate: FamilyScrollViewDelegate?
   private var previousContentOffset: CGPoint = .init(x: -1, y: -1)
   public override var isFlipped: Bool { return true }
 
@@ -46,7 +51,11 @@ public class FamilyScrollView: NSScrollView {
   internal var isChildViewController: Bool = false
   internal var layoutIsRunning: Bool = false
   internal var isScrollingWithWheel: Bool = false
-  internal var isScrolling: Bool = false
+  internal var isScrolling: Bool = false {
+    willSet {
+      delegate?.familyScrollView(self, didScrollToPoint: contentOffset, isScrolling: newValue)
+    }
+  }
   internal var isScrollingByProxy: Bool = false
   internal var isPerformingBatchUpdates: Bool = false
   private var subviewsInLayoutOrder = [NSScrollView]()


### PR DESCRIPTION
Adds a new public delegate protocol called `FamilyScrollViewDelegate`
It can be used to monitor scrolling inside a `FamilyScrolliew` on macOS.
It has one method wit the following signature:

```swift
func familyScrollView(_ scrollView: FamilyScrollView, didScrollToPoint point: CGPoint, isScrolling: Bool)
```