### PR TITLE
Optimize scroll view on iOS when batch updating

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.22.8"
+  s.version          = "0.22.9"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -256,6 +256,7 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
 
     invalidateLayout()
     setNeedsLayout()
+    guard !isPerformingBatchUpdates else { return }
     layoutIfNeeded()
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -376,7 +376,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     scrollView.layoutViews(withDuration: duration, animation: animation) {
       completion?(self)
     }
-
+    scrollView.layoutIfNeeded()
     return self
   }
 


### PR DESCRIPTION
Improve performance by not invoking `layoutIfNeeded`
when performing batch updates.