### PR TITLE
Refactor `FamilyScrollView` on macOS

### DIFF
--- a/Sources/macOS/Classes/FamilyClipView.swift
+++ b/Sources/macOS/Classes/FamilyClipView.swift
@@ -7,9 +7,10 @@ class FamilyClipView: NSClipView {
 
   override func scroll(to newOrigin: NSPoint) {
     super.scroll(to: newOrigin)
-    guard let familyScrollView = scrollView, newOrigin.y != contentInsets.top else { return }
-    familyScrollView.isScrollingByProxy = true
-    familyScrollView.scrollTo(newOrigin, in: documentView!)
+    guard let familyScrollView = scrollView else { return }
+    familyScrollView.scrollTo(newOrigin, in: documentView!) {
+      familyScrollView.isScrollingByProxy = false
+    }
   }
 }
 

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -299,8 +299,19 @@ public class FamilyScrollView: NSScrollView {
     }
     super.scrollWheel(with: event)
 
-    isScrolling = !(event.deltaX == 0 && event.deltaY == 0) ||
-      !(event.phase == .ended || event.momentumPhase == .ended)
+    switch event.phase {
+    case .changed, .began:
+      isScrolling = true
+    default:
+
+      switch event.momentumPhase {
+      case .changed:
+        isScrolling = !(event.deltaY == 0)
+      default:
+        isScrolling = false
+      }
+    }
+
     isScrollingWithWheel = isScrolling
 
     layoutViews(withDuration: 0.0, force: false, completion: nil)

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -426,6 +426,8 @@ public class FamilyScrollView: NSScrollView {
           viewFrame.origin.y = padding.top
         } else {
           frame.size.height += padding.top + padding.bottom
+          viewFrame.origin.x = padding.left
+          viewFrame.origin.y = padding.top
         }
 
         viewFrame.size.width = max(scrollView.isHorizontal ? contentSize.width : constrainedWidth, 0)

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -185,12 +185,10 @@ public class FamilyScrollView: NSScrollView {
     }
   }
 
-  func scrollTo(_ point: CGPoint, in view: NSView) {
-    let shouldScrollByProxy = isScrollingByProxy &&
-      !isScrolling && !layoutIsRunning &&
-      view.window?.isVisible == true
-    defer { isScrollingByProxy = false }
-    guard shouldScrollByProxy, let entry = cache.entry(for: view) else {
+  func scrollTo(_ point: CGPoint, in view: NSView, completion: @escaping () -> Void) {
+    guard view.window?.isVisible == true else { return }
+
+    guard isScrollingByProxy, !isScrolling, let entry = cache.entry(for: view) else {
       return
     }
     var newOffset = CGPoint(x: self.contentOffset.x,
@@ -206,6 +204,8 @@ public class FamilyScrollView: NSScrollView {
     contentView.scroll(newOffset)
     // This is invoked to avoid animation stutter.
     contentView.scroll(to: newOffset)
+
+    layoutViews(withDuration: nil, force: true, completion: completion)
   }
 
   // MARK: - Window resizing

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -213,7 +213,7 @@ public class FamilyScrollView: NSScrollView {
   private func processNewWindowSize() {
     guard window != nil else { return }
     cache.invalidate()
-    layoutViews(withDuration: nil, force: false, completion: nil)
+    layoutViews(withDuration: nil, force: true, completion: nil)
   }
 
   @objc open func windowDidResize(_ notification: Notification) {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -96,7 +96,7 @@ public class FamilyScrollView: NSScrollView {
                           allowsImplicitAnimation: Bool = true,
                           force: Bool,
                           completion: (() -> Void)?) {
-    guard isPerformingBatchUpdates == false, !isDeallocating else { return }
+    guard isPerformingBatchUpdates == false, !isDeallocating, window != nil else { return }
 
     let shouldLayoutViews = subviewsInLayoutOrder.first(where: { $0.layer?.animationKeys() != nil }) != nil
     guard contentOffset != previousContentOffset || cache.state == .empty || shouldLayoutViews else {

--- a/Sources/macOS/Classes/FamilyScrollView.swift
+++ b/Sources/macOS/Classes/FamilyScrollView.swift
@@ -303,7 +303,6 @@ public class FamilyScrollView: NSScrollView {
     case .changed, .began:
       isScrolling = true
     default:
-
       switch event.momentumPhase {
       case .changed:
         isScrolling = !(event.deltaY == 0)
@@ -320,6 +319,7 @@ public class FamilyScrollView: NSScrollView {
   func wrapperViewDidChangeFrame(_ view: NSView, from fromValue: CGRect, to toValue: CGRect) {
     guard window != nil else { return }
     guard round(fromValue.height) != round(toValue.height) else { return }
+    guard cache.state != .isRunning else { return }
     cache.invalidate()
     layoutViews(withDuration: nil,
                 allowsImplicitAnimation: false,

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -357,7 +357,9 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
   /// - Parameter viewController: The target view controller
   /// - Returns: True if the view controller is fully visible on screen
   public func viewControllerIsFullyVisible(_ viewController: ViewController) -> Bool {
-    guard let attributes = scrollView.getValidAttributes(in: scrollView.documentVisibleRect).first(where: { $0.view == viewController.view && $0.view.frame.size.height != 0 }) else {
+    guard let attributes = scrollView.getValidAttributes(in: scrollView.documentVisibleRect)
+      .filter({ $0.view == viewController.view })
+      .first(where: { ( $0.view.enclosingScrollView?.frame.size.height != 0) }) else {
       return false
     }
     let convertedFrame = scrollView.familyDocumentView.convert(attributes.scrollView.frame,

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -86,9 +86,9 @@ class FamilyWrapperView: NSScrollView {
     if familyScrollView.cache.state != .isRunning {
       familyScrollView.cache.invalidate()
       familyScrollView.layoutViews(withDuration: nil,
-                                    allowsImplicitAnimation: false,
-                                    force: true,
-                                    completion: nil)
+                                   allowsImplicitAnimation: false,
+                                   force: true,
+                                   completion: nil)
       guard needsDisplay else { return }
       familyScrollView.setNeedsDisplay(frame)
       familyScrollView.layoutSubtreeIfNeeded()

--- a/Sources/macOS/Classes/FamilyWrapperView.swift
+++ b/Sources/macOS/Classes/FamilyWrapperView.swift
@@ -80,15 +80,19 @@ class FamilyWrapperView: NSScrollView {
   }
 
   private func invalidateFamilyScrollView(needsDisplay: Bool) {
-    guard familyScrollView?.isPerformingBatchUpdates == false else { return }
-    familyScrollView?.cache.invalidate()
-    familyScrollView?.layoutViews(withDuration: nil,
-                                  allowsImplicitAnimation: false,
-                                  force: true,
-                                  completion: nil)
-    guard needsDisplay else { return }
-    familyScrollView?.setNeedsDisplay(frame)
-    familyScrollView?.layoutSubtreeIfNeeded()
+    guard let familyScrollView = familyScrollView else { return }
+    guard familyScrollView.isPerformingBatchUpdates == false else { return }
+
+    if familyScrollView.cache.state != .isRunning {
+      familyScrollView.cache.invalidate()
+      familyScrollView.layoutViews(withDuration: nil,
+                                    allowsImplicitAnimation: false,
+                                    force: true,
+                                    completion: nil)
+      guard needsDisplay else { return }
+      familyScrollView.setNeedsDisplay(frame)
+      familyScrollView.layoutSubtreeIfNeeded()
+    }
   }
 
   private func setWrapperFrameSize(_ rect: CGRect) {

--- a/Tests/Shared/FamilyViewControllerSharedTests.swift
+++ b/Tests/Shared/FamilyViewControllerSharedTests.swift
@@ -18,8 +18,9 @@ class FamilyViewControllerSharedTests: XCTestCase {
     container.view.frame.size = CGSize(width: 500, height: 1000)
     container.scrollView.frame.size = CGSize(width: 500, height: 1000)
     #if os(macOS)
-    container.loadView()
-    container.scrollView.layoutViews(withDuration: nil, force: false, completion: nil)
+    let window = NSWindow(contentViewController: container)
+    container.scrollView.layoutViews(withDuration: nil, force: true, completion: nil)
+    window.makeKeyAndOrderFront(nil)
     #else
     container.loadViewIfNeeded()
     container.scrollView.layoutViews()

--- a/Tests/macOS/FamilyScrollViewTests.swift
+++ b/Tests/macOS/FamilyScrollViewTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import Family
 
+class MockedViewController: NSViewController {
+  override func loadView() {
+    view = NSView()
+  }
+}
+
 class FamilyScrollViewTests: XCTestCase {
   class CollectionViewFlowLayoutMock: NSCollectionViewFlowLayout {
     var contentSize: CGSize = CGSize(width: 100, height: 100)
@@ -8,26 +14,20 @@ class FamilyScrollViewTests: XCTestCase {
   }
 
   static let mockFrame = CGRect(origin: .zero, size: CGSize(width: 500, height: 1000))
-  let superview = NSView(frame: FamilyScrollViewTests.mockFrame)
+  var window: NSWindow!
   var scrollView: FamilyScrollView!
 
   override func setUp() {
     super.setUp()
+    let contentViewController = MockedViewController()
+    contentViewController.view.frame = FamilyScrollViewTests.mockFrame
+    window = NSWindow(contentViewController: contentViewController)
     scrollView = FamilyScrollView()
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    superview.subviews.forEach { $0.removeFromSuperview() }
+    contentViewController.view.addSubview(scrollView)
+    window.makeKeyAndOrderFront(nil)
   }
 
   func testLayoutAlgorithm() {
-    superview.addSubview(scrollView)
-
-    XCTAssertEqual(scrollView.contentSize, superview.bounds.size)
-    // Should set the same height as the super view.
-    XCTAssertEqual(superview.bounds, scrollView.frame)
-
     let size = CGSize(width: 500, height: 250)
     let mockedScrollView1 = NSScrollView(frame: CGRect(origin: .zero, size: size))
     let mockedScrollView2 = NSScrollView(frame: CGRect(origin: .zero, size: size))

--- a/Tests/macOS/FamilyViewControllerTests.swift
+++ b/Tests/macOS/FamilyViewControllerTests.swift
@@ -1,15 +1,8 @@
 import XCTest
 @testable import Family
 
-private extension NSViewController {
-  func prepareViewController() {
-    let _ = view
-    viewWillAppear()
-    viewDidAppear()
-  }
-}
-
 class FamilyViewControllerTests: XCTestCase {
+  var window: NSWindow!
   var familyViewController: FamilyViewController!
 
   class MockScrollViewController: MockViewController {
@@ -31,12 +24,15 @@ class FamilyViewControllerTests: XCTestCase {
   override func setUp() {
     super.setUp()
     familyViewController = FamilyViewController()
-    familyViewController.prepareViewController()
+    familyViewController.view.frame.size = CGSize(width: 375, height: 667)
+    window = NSWindow(contentViewController: familyViewController)
+    window.makeKeyAndOrderFront(nil)
     NSAnimationContext.current.duration = 0.0
   }
 
   func testAddingChildViewController() {
     let viewController = MockViewController()
+    viewController.view.frame.size.height = 667
     familyViewController.addChild(viewController)
     XCTAssertEqual(viewController.parent, familyViewController)
     XCTAssertEqual(viewController.view.frame, familyViewController.view.frame)
@@ -122,7 +118,9 @@ class FamilyViewControllerTests: XCTestCase {
   func testViewControllerIsVisibleMethods() {
     let familyViewController = FamilyViewController()
     familyViewController.view.frame.size = CGSize(width: 375, height: 667)
-    familyViewController.prepareViewController()
+
+    let window = NSWindow(contentViewController: familyViewController)
+    window.makeKeyAndOrderFront(nil)
 
     let controller1 = MockViewController()
     let controller2 = MockViewController()
@@ -181,7 +179,8 @@ class FamilyViewControllerTests: XCTestCase {
   func testAttributesForViewController() {
     let familyViewController = FamilyViewController()
     familyViewController.view.frame.size = CGSize(width: 375, height: 667)
-    familyViewController.prepareViewController()
+    let window = NSWindow(contentViewController: familyViewController)
+    window.makeKeyAndOrderFront(nil)
 
     let controller1 = MockViewController()
     controller1.view.frame.size = CGSize(width: 375, height: 667)
@@ -199,7 +198,6 @@ class FamilyViewControllerTests: XCTestCase {
   func testBatchUpdates() {
     let familyViewController = FamilyViewController()
     familyViewController.view.frame.size = CGSize(width: 375, height: 667)
-    familyViewController.prepareViewController()
 
     let controller1 = MockViewController()
     controller1.title = "Controller 1"
@@ -226,7 +224,6 @@ class FamilyViewControllerTests: XCTestCase {
     let window = NSWindow(contentViewController: familyViewController)
     window.setFrame(NSRect.init(origin: .zero, size: CGSize(width: 375, height: 667)), display: false)
     familyViewController.view.frame.size = CGSize(width: 375, height: 667)
-    familyViewController.prepareViewController()
 
     let controller1 = MockViewController()
     controller1.title = "Controller 1"


### PR DESCRIPTION
This PR refactors some internal parts of the Family Scroll View on macOS.
Probably the most important part is the cache fix where the cache could end
up being lost because the cached attributes were removed as soon as they were
added during the initial layout run.

Changes:

- Force layoutViews when window resizes
- Fix caching bug
  Avoid clearing the view cache while the caching state is set to `isRunning`

- A clean layout run will now take the current content offset into account
- A clean layout run will now stop when it is done processing the views,
   this reduces the amount of processing required during the initial run
- The layout algorithm will no longer produces or set negative values to
   variables such as width and height
- `scrollTo(_ point: CGPoint, in view: NSView)` has gotten a new completion
   argument in its signature
- At the end of the method, we will now explicitly make a call to force a
   call to `layoutViews`
- Improve how `isScrolling` is detected by checking both the `phase` and
   `momentumPhase`
- Check for window before trying to layout views

This PR is brought to you by Finse, a lovely place in the heart of Norway.
You should visit it sometime. Fun fact about Finse, parts of Empire Strikes
Back were filmed there (the part with all the snow).