### PR TITLE
Add completion boolean to layoutViews

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "0.22.11"
+  s.version          = "0.23.0"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyScrollView.swift
@@ -480,11 +480,11 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
   ///                       out from animating if the view is scroll by the user.
   public func layoutViews(withDuration duration: Double? = nil,
                           animation: CAAnimation? = nil,
-                          completion: (() -> Void)? = nil) {
-    guard !isPerformingBatchUpdates else { return }
-    guard !isDeallocating else { return }
-    guard superview != nil else {
-      completion?()
+                          completion: ((Bool) -> Void)? = nil) {
+    guard !isDeallocating,
+      !isPerformingBatchUpdates,
+      superview != nil else {
+      completion?(false)
       return
     }
 
@@ -499,7 +499,7 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
     let options: UIView.AnimationOptions = [.allowUserInteraction, .beginFromCurrentState, .preferredFramesPerSecond60]
     let animations = { self.runLayoutSubviewsAlgorithm() }
     let animationCompletion: (Bool) -> Void = { _ in
-      completion?()
+      completion?(true)
     }
 
     if #available(iOS 9.0, *) {
@@ -524,7 +524,7 @@ public class FamilyScrollView: UIScrollView, UIGestureRecognizerDelegate {
                      completion: animationCompletion)
     } else {
       runLayoutSubviewsAlgorithm()
-      completion?()
+      completion?(true)
     }
   }
 

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -369,14 +369,13 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   open func performBatchUpdates(withDuration duration: Double = 0.25,
                                 animation: CAAnimation? = nil,
                                 _ handler: (FamilyViewController) -> Void,
-                                completion: ((FamilyViewController) -> Void)? = nil) -> Self {
+                                completion: ((FamilyViewController, Bool) -> Void)? = nil) -> Self {
     scrollView.disableContentSizeObservers = true
     scrollView.isPerformingBatchUpdates = true
     handler(self)
     scrollView.isPerformingBatchUpdates = false
-    scrollView.layoutIfNeeded()
-    scrollView.layoutViews(withDuration: duration, animation: animation) {
-      completion?(self)
+    scrollView.layoutViews(withDuration: duration, animation: animation) { completed in
+      completion?(self, completed)
       self.scrollView.disableContentSizeObservers = false
     }
     return self


### PR DESCRIPTION
Improve callback when perform batch updates.
The closure will now get an additional boolean indicate if the
render loop was successful or if it was interrupted.