### PR TITLE
Improve invalidation and scrolling performance

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/FamilyCache.swift
+++ b/Sources/Shared/FamilyCache.swift
@@ -13,8 +13,9 @@ class FamilyCache: NSObject {
 
   func add(entry: FamilyViewControllerAttributes) {
     storage[entry.view] = entry
+    entry.previousAttributes = collection.last
     collection.append(entry)
-    collection.sort(by: { $0.frame.maxY < $1.frame.maxY })
+    entry.previousAttributes?.nextAttributes = entry
   }
 
   func entry(for view: View) -> FamilyViewControllerAttributes? {

--- a/Sources/Shared/FamilyViewControllerAttributes.swift
+++ b/Sources/Shared/FamilyViewControllerAttributes.swift
@@ -2,19 +2,22 @@ import CoreGraphics
 
 public class FamilyViewControllerAttributes: NSObject {
   public let view: View
-  public let origin: CGPoint
-  public let contentSize: CGSize
-  public let maxY: CGFloat
+  public var origin: CGPoint
+  public var contentSize: CGSize
+  public var maxY: CGFloat
+  public var nextAttributes: FamilyViewControllerAttributes?
+  public var previousAttributes: FamilyViewControllerAttributes?
   public var frame: CGRect {
     return CGRect(origin: origin, size: contentSize)
   }
   public let scrollView: ScrollView
 
-  init?(view: View, origin: CGPoint, contentSize: CGSize) {
+  init?(view: View, origin: CGPoint, contentSize: CGSize, nextAttributes: FamilyViewControllerAttributes? = nil) {
     self.view = view
     self.origin = origin
     self.contentSize = contentSize
     self.maxY = round(contentSize.height + origin.y)
+    self.nextAttributes = nextAttributes
     #if os(macOS)
     self.scrollView = view.enclosingScrollView!
     #else
@@ -24,6 +27,10 @@ public class FamilyViewControllerAttributes: NSObject {
       return nil
     }
     #endif
+  }
 
+  func updateWithAbsolute(_ absolute: CGFloat) {
+    origin.y = absolute
+    maxY = round(contentSize.height + origin.y)
   }
 }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -370,13 +370,12 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
                                 animation: CAAnimation? = nil,
                                 _ handler: (FamilyViewController) -> Void,
                                 completion: ((FamilyViewController, Bool) -> Void)? = nil) -> Self {
-    scrollView.disableContentSizeObservers = true
     scrollView.isPerformingBatchUpdates = true
     handler(self)
     scrollView.isPerformingBatchUpdates = false
     scrollView.layoutViews(withDuration: duration, animation: animation) { completed in
       completion?(self, completed)
-      self.scrollView.disableContentSizeObservers = false
+      
     }
     return self
   }


### PR DESCRIPTION
- Reduce the amount of invalidations when scrolling through a collection that uses padding and margins
- Adjust cache instead of invalidating the layout when content size changes for an underlying scroll view
- Make `FamilyViewControllerAttributes` into a linked list

Co-Authored-By: Hans Olav <hansoln@users.noreply.github.com>