### PR TITLE
Fix collection view controllers life cycle issue

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "1.1.0"
+  s.version          = "1.1.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -503,6 +503,13 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     switch childController {
     case let collectionViewController as UICollectionViewController:
       if let collectionView = collectionViewController.collectionView {
+        collectionViewController.collectionView.isUserInteractionEnabled = false
+        // Because `UICollectionViewController`'s view is an internal class
+        // (`UICollectionViewControllerWrapperView`), we need to cherry-pick
+        // by adding the collection view as the view that goes into `FamilyScrollView`
+        // and prepend the view controllers view (the internal class) to the bottom
+        // of the hierarchy so that it doesn't cover up the `FamilyScrollView`.
+        self.view.insertSubview(collectionViewController.view, at: 0)
         view = collectionView
       } else {
         assertionFailure("Unable to resolve collection view from controller.")


### PR DESCRIPTION
- Add special treatment for `UICollectionViewController`'s as their view is different from other core classes.

Because `UICollectionViewController`'s view is an internal class
(`UICollectionViewControllerWrapperView`), we need to cherry-pick
by adding the collection view as the view that goes into `FamilyScrollView`
and prepend the view controllers view (the internal class) to the bottom
of the hierarchy so that it doesn't cover up the `FamilyScrollView`.