### PR TITLE
Fix height not correctly resized when remove child

### DIFF
--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -435,6 +435,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       registry.removeValue(forKey: controller)
     }
 
+    scrollView.purgeWrapperViews()
+
     return self
   }
 

--- a/Sources/macOS/Classes/FamilyViewController.swift
+++ b/Sources/macOS/Classes/FamilyViewController.swift
@@ -391,6 +391,9 @@ open class FamilyViewController: NSViewController, FamilyFriendly {
       view.enclosingScrollView?.removeFromSuperview()
       registry.removeValue(forKey: controller)
     }
+
+    scrollView.purgeWrapperViews()
+
     return self
   }
 

--- a/Tests/iOS+tvOS/FamilyViewControllerTests.swift
+++ b/Tests/iOS+tvOS/FamilyViewControllerTests.swift
@@ -95,6 +95,14 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(viewController.view.frame.size.height, 200)
   }
 
+  func testRemovingChildViewController() {
+    let viewController = UIViewController()
+    familyViewController.addChild(viewController)
+    viewController.removeFromParent()
+
+    XCTAssertTrue(familyViewController.children.isEmpty)
+  }
+
   func testFamilyControllerWithTabBar() {
     let tabBarController = UITabBarController()
     tabBarController.setViewControllers([familyViewController], animated: false)

--- a/Tests/macOS/FamilyViewControllerTests.swift
+++ b/Tests/macOS/FamilyViewControllerTests.swift
@@ -99,6 +99,14 @@ class FamilyViewControllerTests: XCTestCase {
     XCTAssertEqual(viewController.view.frame.size.height, 200)
   }
 
+  func testRemovingChildViewController() {
+    let viewController = MockViewController()
+    familyViewController.addChild(viewController)
+    viewController.removeFromParent()
+
+    XCTAssertTrue(familyViewController.children.isEmpty)
+  }
+
   func testViewControllersInLayoutOrder() {
     let familyViewController = FamilyViewController()
     let controller1 = MockViewController()


### PR DESCRIPTION
## Issue

Hello,

First, thanks for your framework we have complex ViewController in our app and this is really useful for us!

I have an issue when I remove a view from the parent view controller. `purgeRemovedViews()` & `scrollView.purgeWrapperViews()` are not called so obviously the height is not correctly resize and a blank space is still visible. 

If you want to test the issue, please find this sample.

[Test no resize height.zip](https://github.com/zenangst/Family/files/5291311/Test.no.resize.height.zip)

## Fix

The fix is pretty simple because all methods already exists. I just create a `removeChild` function (as we have for the `addChild`) to call this private methods `purgeRemovedViews()` & `scrollView.purgeWrapperViews()`.