### PR TITLE
Improve safe area granularity setup

### DIFF
--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -22,9 +22,17 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
       scrollView.isScrollEnabled = !isChildViewController
     }
   }
-  public var safeAreaLayoutConstraints: Bool = true {
+
+  /// Constrain the top to the safe area. `true` by default.
+  public var topSafeAreaLayoutConstraints: Bool = true {
     didSet { configureConstraints() }
   }
+
+  /// Constrain the bottom to the safe area. `true` by default
+  public var bottomSafeAreaLayoutConstraints: Bool = true {
+    didSet { configureConstraints() }
+  }
+
 
   public convenience init(isChildViewController: Bool) {
     self.init(nibName: nil, bundle: nil)
@@ -438,11 +446,11 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     NSLayoutConstraint.deactivate(constraints)
     constraints.removeAll()
     if #available(iOS 11.0, tvOS 11.0, *) {
-      let topAnchor = safeAreaLayoutConstraints
+      let topAnchor = topSafeAreaLayoutConstraints
         ? view.safeAreaLayoutGuide.topAnchor
         : view.topAnchor
 
-      let bottomAnchor = safeAreaLayoutConstraints
+      let bottomAnchor = bottomSafeAreaLayoutConstraints
         ? view.safeAreaLayoutGuide.bottomAnchor
         : view.bottomAnchor
 


### PR DESCRIPTION
## Issue

Hello again 😅! 

I have an issue about the constraints management. Top & Bottom are too close and for me this is missing granularity to handle top & bottom separately.

To explain, easier with an image!

### Basic behavior with `safeAreaLayoutConstraints` at `true`

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-28 at 17 11 51](https://user-images.githubusercontent.com/19798935/94451800-1e0cec00-01af-11eb-98ba-158d5a7a41b5.png)

What's wrong for me? The blank space in bottom.

### Basic behavior with `safeAreaLayoutConstraints` at `false`

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-28 at 17 12 19](https://user-images.githubusercontent.com/19798935/94451811-21a07300-01af-11eb-81a5-255d26c6cbe8.png)

What's wrong for me? The `UINavigationBar` is no more visible.

### The solution. handle top & bottom safe area

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-28 at 17 11 28](https://user-images.githubusercontent.com/19798935/94451826-26fdbd80-01af-11eb-84a9-15497ef192be.png)

🎉 