### PR TITLE
Fix memory leak in `FamilyViewController`

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "2.1.0"
+  s.version          = "2.1.1"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/iOS+tvOS/Classes/FamilyViewController.swift
+++ b/Sources/iOS+tvOS/Classes/FamilyViewController.swift
@@ -420,6 +420,7 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
 
     _viewControllersInLayoutOrder = []
     scrollView.isPerformingBatchUpdates = false
+    purgeRemovedViews()
 
     if duration == 0 {
         scrollView.setNeedsLayout()
@@ -618,5 +619,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
     viewController.removeFromParent()
     viewController.view.removeFromSuperview()
     viewController.didMove(toParent: nil)
+    registry.removeValue(forKey: viewController)
   }
 }


### PR DESCRIPTION
- Make sure that we clear the registry when view controllers are removed
 from the view hierarchy
