### PR TITLE
Improve usage of compositional layouts

### DIFF
--- a/Family.podspec
+++ b/Family.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Family"
   s.summary          = "A child view controller framework that makes setting up your parent controllers as easy as pie."
-  s.version          = "2.2.2"
+  s.version          = "2.2.3"
   s.homepage         = "https://github.com/zenangst/Family"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/FamilyFriendly.swift
+++ b/Sources/Shared/FamilyFriendly.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
 import Foundation
 
-protocol FamilyFriendly: class {
+protocol FamilyFriendly: AnyObject {
   func addChild(_ childController: ViewController)
   func addChild<T: ViewController>(_ childController: T,
                                    at index: Int?,

--- a/Sources/UIKit/FamilyViewController.swift
+++ b/Sources/UIKit/FamilyViewController.swift
@@ -7,7 +7,6 @@ import UIKit
 /// adds the controllers view or custom view to view heirarcy inside the
 /// content view of the `FamilyScrollView`.
 open class FamilyViewController: UIViewController, FamilyFriendly {
-  public static var signpostsEnabled: Bool = false
   var registry = [ViewController: (view: View, observer: NSKeyValueObservation)]()
 
   /// A custom implementation of a `UIScrollView` that handles continious scrolling
@@ -185,13 +184,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   ///
   /// - Parameter childController: The view controller to be added as a child.
   open override func addChild(_ childController: UIViewController) {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     if childController.parent != nil {
       childController.removeFromParent()
     }
@@ -222,13 +214,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
                                             insets: Insets? = nil,
                                             height: CGFloat? = nil,
                                             view handler: ((T) -> UIView)? = nil) -> Self {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     purgeRemovedViews()
     childController.willMove(toParent: self)
     super.addChild(childController)
@@ -286,13 +271,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
                       at index: Int? = nil,
                       insets: Insets? = nil,
                       height: CGFloat? = nil) -> Self {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     var newWidth = view.bounds.size.width
 
     if let insets = insets {
@@ -326,13 +304,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   ///
   /// - Returns: A collection of view controllers.
   public func viewControllersInLayoutOrder() -> [ViewController] {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     if !_viewControllersInLayoutOrder.isEmpty {
       return _viewControllersInLayoutOrder
     }
@@ -405,25 +376,8 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
                                 animation: CAAnimation? = nil,
                                 _ handler: (FamilyViewController) -> Void,
                                 completion: ((FamilyViewController, Bool) -> Void)? = nil) -> Self {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     scrollView.isPerformingBatchUpdates = true
-    if Self.signpostsEnabled {
-      let handlerLog = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                            name: "performBatchupdates.handler",
-                                            signpostsEnabled: Self.signpostsEnabled)
-      handlerLog.signpost(.begin, "performBatchupdates.handler")
-      handler(self)
-      handlerLog.signpost(.end, "performBatchupdates.handler")
-    } else {
-      handler(self)
-    }
-
+    handler(self)
     _viewControllersInLayoutOrder = []
     scrollView.isPerformingBatchUpdates = false
 
@@ -489,13 +443,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   public func purgeRemovedViews() -> Self {
     if scrollView.isPerformingBatchUpdates { return self }
 
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     for (controller, container) in registry where controller.parent == nil {
       _removeChild(controller)
       if container.view.superview is FamilyWrapperView {
@@ -558,13 +505,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   ///           on if an index is provided.
   ///   - index: An optional index for where the view should appear.
   private func addOrInsertView(_ view: UIView, at index: Int? = nil) {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     if let index = index, index < scrollView.subviews.count {
       scrollView.insertSubview(view, at: index)
     } else {
@@ -585,13 +525,6 @@ open class FamilyViewController: UIViewController, FamilyFriendly {
   /// - Returns: A view that matches the criteria depending on the
   ///            view controllers type.
   private func viewToAdd(from childController: UIViewController) -> View {
-    if Self.signpostsEnabled {
-      let log = OSSignpostController(category: String(describing: FamilyViewController.self),
-                                     signpostsEnabled: Self.signpostsEnabled)
-      log.signpost(.begin, #function)
-      defer { log.signpost(.end, #function) }
-    }
-
     let view: UIView
 
     switch childController {


### PR DESCRIPTION
- Remove signposting code
- Apply fix when using compositional layouts
- Bump version to 2.2.3
- Fix warning with using the `class` keyword instead of `AnyObject` on
  the `FamilyFriendly` protocol
